### PR TITLE
Documentation updates, added functionality to get_traces_midgz

### DIFF
--- a/rqpy/plotting/_plotting.py
+++ b/rqpy/plotting/_plotting.py
@@ -382,23 +382,23 @@ def densityplot(xvals, yvals, xlims=None, ylims=None, nbins = (500,500), cut=Non
 
     return fig, ax
 
-def plot_gauss(x, bins, y, fitparams, errors, background, labeldict):
+def plot_gauss(x, bins, y, fitparams, errors, background, labeldict=None):
     """
     Hidden helper function to plot Gaussian plus background fits
     
     Parameters
     ----------
-    x: array
+    x : array
         Array of x data
-    bins: array
+    bins : array
         Array of binned data
-    y: array
+    y : array
         Array of y data
-    fitparams: tuple
+    fitparams : tuple
         The best fit parameters from the fit
-    errors: tuple
+    errors : tuple
         The unccertainy in the best fit parameters
-    background: float,
+    background : float
         The average background rate
     labeldict : dict, optional
         Dictionary to overwrite the labels of the plot. defaults are : 
@@ -407,10 +407,11 @@ def plot_gauss(x, bins, y, fitparams, errors, background, labeldict):
         
     Returns
     -------
-    fig: matrplotlib figure object
-    
-    ax: matplotlib axes object
-    
+    fig : Figure
+        Matplotlib Figure object. Set to None if ax is passed as a parameter.
+    ax : axes.Axes object
+        Matplotlib Axes object
+        
     """
     
     x_fit = np.linspace(x[0], x[-1], 250) #make x data for fit
@@ -440,21 +441,20 @@ def plot_gauss(x, bins, y, fitparams, errors, background, labeldict):
     
     return fig, ax
     
-def plot_n_gauss(x, y, bins, fitparams, labeldict, ax = None):
+def plot_n_gauss(x, y, bins, fitparams, labeldict=None, ax=None):
     """
     Hidden helper function to plot and arbitrary number of Gaussians plus background fit
     
     Parameters
     ----------
-    x: array
+    x : ndarray
         Array of x data
-    y: array
+    y : ndarray
         Array of y data
-    bins: array
+    bins : ndarray
         Array of binned data
-    fitparams: tuple
+    fitparams : tuple
         The best fit parameters from the fit
-    
     labeldict : dict, optional
         Dictionary to overwrite the labels of the plot. defaults are : 
             labels = {'title' : 'Histogram', 'xlabel' : 'variable', 'ylabel' : 'Count'}
@@ -462,11 +462,13 @@ def plot_n_gauss(x, y, bins, fitparams, labeldict, ax = None):
         
     Returns
     -------
-    fig: matrplotlib figure object
-    
-    ax: matplotlib axes object
-    
+    fig : Figure
+        Matplotlib Figure object. Set to None if ax is passed as a parameter.
+    ax : axes.Axes object
+        Matplotlib Axes object
+        
     """
+    
     n = int((len(fitparams)-1)/3)
     
     x_fit = np.linspace(x[0], x[-1], 250) #make x data for fit

--- a/rqpy/process/_process_iv_didv.py
+++ b/rqpy/process/_process_iv_didv.py
@@ -4,7 +4,6 @@ import os
 import multiprocessing
 from itertools import repeat
 from rqpy import io
-from qetpy import fitting
 from rqpy import HAS_SCDMSPYTOOLS
 
 if HAS_SCDMSPYTOOLS:
@@ -14,46 +13,38 @@ if HAS_SCDMSPYTOOLS:
 __all__ = ["process_ivsweep"]
 
 
-
-
-
-
-
-
-
-
 def _process_ivfile(filepath, channels, detectorid, rfb, loopgain, binstovolts, 
-                 rshunt, rbias, lgcHV):
+                    rshunt, rbias, lgcHV):
     """
     Helper function to process data from noise or dIdV series as part of an IV/dIdV sweep. See Notes for 
     more details on what parameters are calculated
     
     Parameters
     ----------
-    filepath: str
+    filepath : str
         Absolute path to the series folder
-    channels: list
+    channels : list
         List containing strings corresponding to the names of all the channels of interest
-    detectorid: str
+    detectorid : str
         The label of the detector, i.e. Z1, Z2, .. etc
-    rfb: int
+    rfb : int
         The resistance of the feedback resistor in the phonon amplifier
-    loopgain: float
+    loopgain : float
         The ratio of number of turns in the squid input coil vs feedback coil
-    binstovolts: int
+    binstovolts : int
         The bit depth divided by the dynamic range of the ADC in Volts
-    rshunt: float
+    rshunt : float
         The value of the shunt resistor in the TES circuit
-    rbias: int
+    rbias : int
         The value of the bias resistor on the test signal line
-    lgcHV: bool
+    lgcHV : bool
         If False (default), the detector is assumed to be operating in iZip mode, 
         If True, HV mode. Note, the channel names will be different between the 
         two modes, it is up to the user to make sure the channel names are correct
         
     Returns
     -------
-    data_list: list
+    data_list : list
         The list of calculated parameters
         
     Notes
@@ -205,48 +196,48 @@ def _process_ivfile(filepath, channels, detectorid, rfb, loopgain, binstovolts,
 
 
 def process_ivsweep(ivfilepath, channels, detectorid="Z1", rfb=5000, loopgain=2.4, binstovolts=65536/2, 
-                 rshunt=0.005, rbias=20000, lgcHV = False, nprocess = 1, savepath = '', savename = 'IV_dIdV_DF'):
+                    rshunt=0.005, rbias=20000, lgcHV=False, nprocess=1, savepath='', savename='IV_dIdV_DF'):
     """
     Function to process data for an IV/dIdV sweep. See Notes for 
     more details on what parameters are calculated
     
     Parameters
     ----------
-    ivfilepath: str
+    ivfilepath : str
         Absolute path to the directory containing all the series in the sweep
-    channels: list
+    channels : list
         List containing strings corresponding to the names of all the channels of interest
-    detectorid: str, optional
+    detectorid : str, optional
         The label of the detector, i.e. Z1, Z2, .. etc
-    rfb: int
+    rfb : int
         The resistance of the feedback resistor in the phonon amplifier
-    loopgain: float, optional
+    loopgain : float, optional
         The ratio of number of turns in the squid input coil vs feedback coil
-    binstovolts: int, optional
+    binstovolts : int, optional
         The bit depth divided by the dynamic range of the ADC in Volts
-    rshunt: float, optional
+    rshunt : float, optional
         The value of the shunt resistor in the TES circuit
-    rbias: int, optional
+    rbias : int, optional
         The value of the bias resistor on the test signal line
-    lgcHV: bool, optional
+    lgcHV : bool, optional
         If False (default), the detector is assumed to be operating in iZip mode, 
         If True, HV mode. Note, the channel names will be different between the 
         two modes, it is up to the user to make sure the channel names are correct
-    nprocess: int
+    nprocess : int
         Number of jobs to use to process IV dIdV sweep. If nprocess = 1, only a single
         core will be used. If more than one, Pool will be used for multiprocessing. 
         Note, if you are running this on a shared computer, no more than 4 jobs should be
         used, idealy 2, as it will significantly slow down the computer.
-    lgcsave: bool, optional
+    lgcsave : bool, optional
         If True, the processed DataFrame will be saved
-    savepath: str, optional
+    savepath : str, optional
         Abosolute path to save DataFrame
-    savename: str, optional
+    savename : str, optional
         The name of the processed DataFrame to be saved
         
     Returns
     -------
-    df:  pandas.DataFrame
+    df : pandas.DataFrame
         A pandas DataFrame with all the processed parameters for the IV dIdV sweep
         
     Notes
@@ -274,17 +265,15 @@ def process_ivsweep(ivfilepath, channels, detectorid="Z1", rfb=5000, loopgain=2.
     
     """
     if not HAS_SCDMSPYTOOLS:
-        raise ImportError("Cannot use this IV processing because scdmsPyTools is not installed. \n More file types will be supported in future releases of RQpy.")
+        raise ImportError("""Cannot use this IV processing because scdmsPyTools is not installed. 
+                          More file types will be supported in future releases of RQpy.""")
     
     if nprocess == 1:
         results = []
         for filepath in ivfilepath:
             results.append(_process_ivfile(filepath, channels, detectorid, rfb, loopgain, binstovolts, 
                  rshunt, rbias, lgcHV))
-            
-            
     else:
-        
         pool = multiprocessing.Pool(processes = int(nprocess))
         results = pool.starmap(_process_ivfile, zip(files, repeat(channels, detectorid, rfb, loopgain, binstovolts, 
                  rshunt, rbias, lgcHV))) 
@@ -300,7 +289,5 @@ def process_ivsweep(ivfilepath, channels, detectorid="Z1", rfb=5000, loopgain=2.
         df.to_pickle(f"{savepath}{savename}.pkl")
     
     return df
-    
-    
     
     

--- a/rqpy/process/_trigger.py
+++ b/rqpy/process/_trigger.py
@@ -5,7 +5,6 @@ from numpy.random import choice
 from collections import Counter
 from math import log10, floor
 from rqpy.io import loadstanfordfile
-from rqpy.core._cut import inrange
 import datetime
 
 


### PR DESCRIPTION
The changes are as follows:
1. Make the documentation and optional arguments for various functions follow the proper conventions
2. Update `get_traces_npz` documentation (issue #13)
3. Add `lgcreturndict` optional argument to `get_traces_midgz` so that the user can choose not to return the dictionary with all of the event information if it is unnecessary.
4. Take out a couple imports that are unused