### PR TITLE
change get_traces_midgz defaults 

### DIFF
--- a/rqpy/io/_io.py
+++ b/rqpy/io/_io.py
@@ -234,7 +234,7 @@ def get_trace_gain(path, chan, det, gainfactors = {'rfb': 5000, 'loopgain' : 2.4
     
     return convtoamps, drivergain, qetbias
 
-def get_traces_midgz(path, channels, det, convtoamps=1, lgcskip_empty=False, lgcreturndict=True):
+def get_traces_midgz(path, channels, det, convtoamps=1, lgcskip_empty=True, lgcreturndict=False):
     """
     Function to return raw traces and event information for a single channel for mid.gz files.
     

--- a/rqpy/process/_process_rq.py
+++ b/rqpy/process/_process_rq.py
@@ -707,7 +707,8 @@ def _rq(file, channels, det, setup, convtoamps, savepath, lgcsavedumps, filetype
         raise ValueError("channels and det should have the same length")
     
     if filetype == "mid.gz":
-        traces, info_dict = io.get_traces_midgz([file], channels=channels, det=det, convtoamps=convtoamps)
+        traces, info_dict = io.get_traces_midgz([file], channels=channels, det=det, convtoamps=convtoamps,
+                                                lgcskip_empty=False, lgcreturndict=True)
     elif filetype == "npz":
         traces, info_dict = io.get_traces_npz([file])
     


### PR DESCRIPTION
`get_traces_midgz` now defaults to `lgcskip_empty=True` and `lgcreturndict=False` as requested by Issue #19.