### PR TITLE
hist() and scatter() now support arbitrary numbers of cuts for plotting

### DIFF
--- a/rqpy/plotting/_plotting.py
+++ b/rqpy/plotting/_plotting.py
@@ -22,21 +22,23 @@ def hist(arr, nbins='sqrt', xlims=None, cuts=None, lgcrawdata=True,
     xlims : list of float, optional
         The xlimits of the histogram. This is passed to plt.hist() range parameter.
     cuts : list, optional
-        List of masks of values to be plotted. The cuts will be applied in the order that they are listed, such
-        that ay number of cuts can be plotted
+        List of masks of values to be plotted. The cuts will be applied in the order that they are listed, 
+        such that any number of cuts can be plotted
     lgcrawdata : bool, optional
         If True, the raw data is plotted
     lgceff : bool, optional
-        If True, the cut efficiencies are printed in the legend. The total eff will be the sum of all the 
-        cuts divided by the length of the data. The current cut eff will be the sum of the current cut 
-        divided by the sum of all the previous cuts, if any.
+        If True, the cut efficiencies are printed in the legend. 
     lgclegend : bool, optional
         If True, the legend is plotted.
     labeldict : dict, optional
         Dictionary to overwrite the labels of the plot. defaults are: 
-            labels = {'title' : 'Histogram', 'xlabel' : 'variable', 'ylabel' : 'Count', 
-                      'cut0' : '1st', 'cut1' : '2nd', ...}
-        Ex: to change just the title, pass: labeldict = {'title' : 'new title'}, to histrq()
+            labels = {'title' : 'Histogram', 
+                      'xlabel' : 'variable', 
+                      'ylabel' : 'Count', 
+                      'cut0' : '1st', 
+                      'cut1' : '2nd', 
+                      ...}
+        Ex: to change just the title, pass: labeldict = {'title' : 'new title'}, to hist()
     ax : axes.Axes object, optional
         Option to pass an existing Matplotlib Axes object to plot over, if it already exists.
     cmap : str, optional
@@ -128,8 +130,8 @@ def hist(arr, nbins='sqrt', xlims=None, cuts=None, lgcrawdata=True,
     return fig, ax
     
 
-def scatter(xvals, yvals, xlims=None, ylims=None, cutold=None, cutnew=None, 
-            lgcrawdata=True, lgceff=True, lgclegend=True, labeldict=None, ms=1, a=.3, ax=None):
+def scatter(xvals, yvals, xlims=None, ylims=None, cuts=None, lgcrawdata=True, lgceff=True, 
+            lgclegend=True, labeldict=None, ms=1, a=.3, ax=None, cmap="viridis"):
     """
     Function to plot RQ data as a scatter plot.
     
@@ -145,29 +147,33 @@ def scatter(xvals, yvals, xlims=None, ylims=None, cutold=None, cutnew=None,
     ylims : list of float, optional
         This is passed to the plot as the y limits. Automatically determined from range of data
         if not set.
-    cutold : array of bool, optional
-        Mask of values to be plotted
-    cutnew : array of bool, optional
-        Mask of values to be plotted. This mask is added to cutold if cutold is not None. 
+    cuts : list, optional
+        List of masks of values to be plotted. The cuts will be applied in the order that they are listed,
+        such that any number of cuts can be plotted
     lgcrawdata : bool, optional
         If True, the raw data is plotted
     lgceff : bool, optional
-        If True, the cut efficiencies are printed in the legend. The total eff will be the sum of all the 
-        cuts divided by the length of the data. The current cut eff will be the sum of the current cut 
-        divided by the sum of all the previous cuts, if any.
+        If True, the efficiencies of each cut, with respect to the data that survived 
+        the previous cut, are printed in the legend. 
     lgclegend : bool, optional
-        If True, the legend is plotted.
+        If True, the legend is included in the plot.
     labeldict : dict, optional
-        Dictionary to overwrite the labels of the plot. defaults are : 
-            labels = {'title' : 'Histogram', 'xlabel' : 'variable', 'ylabel' : 'Count', 
-            'cutnew' : 'current', 'cutold' : 'previous'}
-        Ex: to change just the title, pass: labeldict = {'title' : 'new title'}, to histrq()
+        Dictionary to overwrite the labels of the plot. defaults are: 
+            labels = {'title' : 'Scatter Plot', 
+                      'xlabel' : 'x variable', 
+                      'ylabel' : 'y variable', 
+                      'cut0' : '1st', 
+                      'cut1' : '2nd', 
+                      ...}
+        Ex: to change just the title, pass: labeldict = {'title' : 'new title'}, to scatter()
     ms : float, optional
         The size of each marker in the scatter plot. Default is 1
     a : float, optional
         The opacity of the markers in the scatter plot, i.e. alpha. Default is 0.3
     ax : axes.Axes object, optional
         Option to pass an existing Matplotlib Axes object to plot over, if it already exists.
+    cmap : str, optional
+        The colormap to use for plotting each cut. Default is 'viridis'.
     
     Returns
     -------
@@ -178,15 +184,30 @@ def scatter(xvals, yvals, xlims=None, ylims=None, cutold=None, cutnew=None,
         
     """
 
+    if not isinstance(cuts, list):
+        cuts = [cuts]
+    
     labels = {'title'  : 'Scatter Plot',
               'xlabel' : 'x variable', 
-              'ylabel' : 'y variable', 
-              'cutnew' : 'current', 
-              'cutold' : 'previous'}
+              'ylabel' : 'y variable'}
     
+    for ii in range(len(cuts)):
+        
+        num_str = str(ii+1)
+        
+        if num_str[-1]=='1':
+            num_str+="st"
+        elif num_str[-1]=='2':
+            num_str+="nd"
+        elif num_str[-1]=='3':
+            num_str+="rd"
+        else:
+            num_str+="th"
+        
+        labels[f"cut{ii}"] = num_str
+        
     if labeldict is not None:
-        for key in labeldict:
-            labels[key] = labeldict[key]
+        labels.update(labeldict)
     
     if ax is None:
         fig, ax = plt.subplots(figsize=(9, 6))
@@ -201,83 +222,60 @@ def scatter(xvals, yvals, xlims=None, ylims=None, cutold=None, cutnew=None,
         xlimitcut = (xvals>xlims[0]) & (xvals<xlims[1])
     else:
         xlimitcut = np.ones(len(xvals), dtype=bool)
+        
     if ylims is not None:
         ylimitcut = (yvals>ylims[0]) & (yvals<ylims[1])
     else:
         ylimitcut = np.ones(len(yvals), dtype=bool)
-
+    
     limitcut = xlimitcut & ylimitcut
     
-    if lgcrawdata and cutold is not None: 
-        ax.scatter(xvals[limitcut & ~cutold], yvals[limitcut & ~cutold], 
-                   label='Full Data', c='b', s=ms, alpha=a)
-    elif lgcrawdata and cutnew is not None: 
-        ax.scatter(xvals[limitcut & ~cutnew], yvals[limitcut & ~cutnew], 
+    if lgcrawdata and cuts is not None: 
+        ax.scatter(xvals[limitcut & ~cuts[0]], yvals[limitcut & ~cuts[0]], 
                    label='Full Data', c='b', s=ms, alpha=a)
     elif lgcrawdata:
         ax.scatter(xvals[limitcut], yvals[limitcut], 
                    label='Full Data', c='b', s=ms, alpha=a)
-        
-    if cutold is not None:
-        oldsum = cutold.sum()
-        if cutnew is None:
-            cuteff = cutold.sum()/cutold.shape[0]
-            cutefftot = cuteff
-            
-        label = f"Data passing {labels['cutold']} cut"
-        if cutnew is None:
-            ax.scatter(xvals[cutold & limitcut], yvals[cutold & limitcut], 
-                       label=label, c='r', s=ms, alpha=a)
-        else: 
-            ax.scatter(xvals[cutold & limitcut & ~cutnew], yvals[cutold & limitcut & ~cutnew], 
-                       label=label, c='r', s=ms, alpha=a)
-        
-    if cutnew is not None:
-        newsum = cutnew.sum()
-        if cutold is not None:
-            cutnew = cutnew & cutold
-            cuteff = cutnew.sum()/oldsum
-            cutefftot = cutnew.sum()/cutnew.shape[0]
-        else:
-            cuteff = newsum/cutnew.shape[0]
-            cutefftot = cuteff
-            
-        if lgceff:
-            label = f"Data passing {labels['cutnew']} cut, eff : {cuteff:.3f}"
-        else:
-            label = f"Data passing {labels['cutnew']} cut"
-            
-        ax.scatter(xvals[cutnew & limitcut], yvals[cutnew & limitcut], 
-                   label=label, c='g', s=ms, alpha=a)
     
-    elif (cutnew is None) & (cutold is None):
-        cuteff = 1
-        cutefftot = 1
+    colors = plt.cm.get_cmap(cmap)(np.linspace(0.1, 0.9, len(cuts)))
+        
+    ctemp = np.ones(len(xvals), dtype=bool)
+    
+    for ii, cut in enumerate(cuts):
+        oldsum = ctemp.sum()
+        ctemp = ctemp & cut
+        newsum = ctemp.sum()
+        cuteff = newsum/oldsum * 100
+        label = f"Data passing {labels[f'cut{ii}']} cut"
+        
+        if lgceff:
+            label+=f", Eff = {cuteff:.1f}%"
+            
+        cplot = ctemp & limitcut
+        
+        if ii+1<len(cuts):
+            cplot = cplot & ~cuts[ii+1]
+        
+        ax.scatter(xvals[cplot], yvals[cplot], 
+                   label=label, c=colors[ii], s=ms, alpha=a)
         
     if xlims is None:
-        if lgcrawdata:
+        if lgcrawdata and cuts is None:
             xrange = xvals.max()-xvals.min()
             ax.set_xlim([xvals.min()-0.05*xrange, xvals.max()+0.05*xrange])
-        elif cutold is not None:
-            xrange = xvals[cutold].max()-xvals[cutold].min()
-            ax.set_xlim([xvals[cutold].min()-0.05*xrange, xvals[cutold].max()+0.05*xrange])
-        elif cutnew is not None:
-            xrange = xvals[cutnew].max()-xvals[cutnew].min()
-            ax.set_xlim([xvals[cutnew].min()-0.05*xrange, xvals[cutnew].max()+0.05*xrange])
+        elif cuts is not None:
+            xrange = xvals[cuts[0]].max()-xvals[cuts[0]].min()
+            ax.set_xlim([xvals[cuts[0]].min()-0.05*xrange, xvals[cuts[0]].max()+0.05*xrange])
     else:
         ax.set_xlim(xlims)
         
     if ylims is None:
-        if lgcrawdata:
+        if lgcrawdata and cuts is None:
             yrange = yvals.max()-yvals.min()
             ax.set_ylim([yvals.min()-0.05*yrange, yvals.max()+0.05*yrange])
-        elif cutold is not None:
-            yrange = yvals[cutold].max()-yvals[cutold].min()
-            ax.set_ylim([yvals[cutold].min()-0.05*yrange, yvals[cutold].max()+0.05*yrange])
-        elif cutnew is not None:
-            yrange = yvals[cutnew].max()-yvals[cutnew].min()
-            ax.set_ylim([yvals[cutnew].min()-0.05*yrange, yvals[cutnew].max()+0.05*yrange])
-        
+        elif cuts is not None:
+            yrange = yvals[cuts[0]].max()-yvals[cuts[0]].min()
+            ax.set_ylim([yvals[cuts[0]].min()-0.05*yrange, yvals[cuts[0]].max()+0.05*yrange])
     else:
         ax.set_ylim(ylims)
         
@@ -286,8 +284,6 @@ def scatter(xvals, yvals, xlims=None, ylims=None, cutold=None, cutnew=None,
     ax.tick_params(which="both", direction="in", right=True, top=True)
     ax.grid(linestyle="dashed")
     
-    if lgceff:
-        ax.plot([], [], linestyle=' ', label=f'Efficiency of total cut: {cutefftot:.3f}')
     if lgclegend:
         ax.legend(markerscale=6, framealpha=.9)
     


### PR DESCRIPTION
I've changed the `rqpy.hist` and `rqpy.scatter` functions to be able to plot any number of cuts that are applied sequentially. The total cut efficiency is no longer calculated, but the efficiency of each cut is. 

This is in response to issue #24.