### PR TITLE
Changed SetupRQ options, added new RQs

### DIFF
--- a/rqpy/process/_process_rq.py
+++ b/rqpy/process/_process_rq.py
@@ -137,6 +137,14 @@ class SetupRQ(object):
     t0_shifted : ndarray
         Attribute used to save the times to shift the non-trigger channels. Only used if `do_ofamp_shifted`
         is True.
+    do_optimumfilters : bool
+        Boolean flag for whether or not any of the optimum filters will be calculated. If only
+        calculating non-OF-related RQs, then this will be False, and processing time will not
+        be spent on initializing the OF.
+    do_optimumfilters_smooth : bool
+        Boolean flag for whether or not any of the smoothed-PDS optimum filters will be calculated. 
+        If only calculating non-OF-related RQs, then this will be False, and processing time will not
+        be spent on initializing the OF.
     
     """
     
@@ -164,14 +172,6 @@ class SetupRQ(object):
         trigger : float, NoneType, optional
             The index corresponding to which channel is the trigger channel in the list of templates
             and psds. If left as None, then no channel is assumed to be the trigger channel.
-        do_optimumfilters : bool
-            Boolean flag for whether or not any of the optimum filters will be calculated. If only
-            calculating non-OF-related RQs, then this will be False, and processing time will not
-            be spent on initializing the OF.
-        do_optimumfilters_smooth : bool
-            Boolean flag for whether or not any of the smoothed-PDS optimum filters will be calculated. 
-            If only calculating non-OF-related RQs, then this will be False, and processing time will not
-            be spent on initializing the OF.
         
         """
         

--- a/rqpy/process/_process_rq.py
+++ b/rqpy/process/_process_rq.py
@@ -340,8 +340,13 @@ class SetupRQ(object):
         
     def _check_arg_length(self, **kwargs):
         """
-        Helper function for checking if the inputted `kwargs` are list type and if they have same
+        Helper function for checking if the inputted `**kwargs` are list type and if they have same
         length as the number of channels.
+        
+        Parameters
+        ----------
+        **kwargs : Arbitrary keyword arguments
+            The inputted keyword arguments to check list type and length.
         
         Returns
         -------
@@ -352,10 +357,10 @@ class SetupRQ(object):
         Raises
         ------
         ValueError
-            A ValueError is raised if the length of one of the `kwargs` is not equal
+            A ValueError is raised if the length of one of the `**kwargs` is not equal
             to `self.chan`.
         ValueError
-            A ValueError is raised if the `kwarg` pulse_direction_constraint is inputted and 
+            A ValueError is raised if the `**kwargs` pulse_direction_constraint is inputted and 
             one of the values is not set to 1, 0, or -1.
         
         """

--- a/rqpy/process/_process_rq.py
+++ b/rqpy/process/_process_rq.py
@@ -241,13 +241,13 @@ class SetupRQ(object):
         self.fs = fs
         self.nchan = len(templates)
         
-        self.indstart = 0
-        self.indstop = len(self.templates[0])
+        self.indstart = indstart
+        self.indstop = indstop
         
-        if self.indstop - self.indstart != len(self.templates[0]):
-            raise ValueError("The indices specified indstart and indstop will result in each"+\
-                             "truncated trace having a different length than their corresponding"+\
-                             "psd and template. Make sure indstart-indstop = the length of the"+\
+        if self.indstart is not None and self.indstop is not None and (self.indstop - self.indstart != len(self.templates[0])):
+            raise ValueError("The indices specified indstart and indstop will result in each "+\
+                             "truncated trace having a different length than their corresponding "+\
+                             "psd and template. Make sure indstart-indstop = the length of the "+\
                              "template/psd")
         
         self.summed_template = summed_template

--- a/rqpy/process/_process_rq.py
+++ b/rqpy/process/_process_rq.py
@@ -370,7 +370,7 @@ class SetupRQ(object):
                 kwargs[key] = [value]*self.nchan
                 
             if key == "pulse_direction_constraint" and not all(x in [-1, 0, 1] for x in kwargs[key]):
-                    raise ValueError(f"{key} should be set to 0, 1, or -1")
+                raise ValueError(f"{key} should be set to 0, 1, or -1")
 
             if len(kwargs[key])!=self.nchan:
                 raise ValueError(f"The length of {key} is not equal to the number of channels")
@@ -646,7 +646,7 @@ class SetupRQ(object):
         
         self._check_of()
         
-    def adjust_baseline(self, lgcrun=True, indbasepre=16000):
+    def adjust_baseline(self, lgcrun=True, indbasepre=None):
         """
         Method for adjusting the calculation of the DC baseline.
         
@@ -663,12 +663,15 @@ class SetupRQ(object):
             
         """
         
+        if indbasepre is None:
+            indbasepre = len(templates[0])//3
+        
         indbasepre = self._check_arg_length(indbasepre=indbasepre)
             
         self.do_baseline = lgcrun
         self.baseline_indbasepre = indbasepre
         
-    def adjust_integral(self, lgcrun=True, indstart=16000, indstop=20000):
+    def adjust_integral(self, lgcrun=True, indstart=None, indstop=None):
         """
         Method for adjusting the calculation of the integral.
         
@@ -686,6 +689,12 @@ class SetupRQ(object):
             truncating the rest of the trace. Default is 20000.
             
         """
+        
+        if indstart is None:
+            indstart = len(templates[0])//3
+            
+        if indstop is None:
+            indstop = 2*len(templates[0])//3
         
         indstart, indstop = self._check_arg_length(indstart=indstart, indstop=indstop)
         

--- a/rqpy/process/_process_rq.py
+++ b/rqpy/process/_process_rq.py
@@ -50,109 +50,127 @@ class SetupRQ(object):
         The index at we should truncate the end of the traces up to when calculating RQs.
     nchan : int
         The number of channels to be processed.
-    do_ofamp_nodelay : bool
+    do_ofamp_nodelay : list of bool
         Boolean flag for whether or not to do the optimum filter fit with no time
-        shifting.
-    do_ofamp_nodelay_smooth : bool
+        shifting. Each value in the list specifies this attribute for each channel.
+    do_ofamp_nodelay_smooth : list of bool
         Boolean flag for whether or not the optimum filter fit with no time
         shifting should be calculated with a smoothed PSD. Useful in the case 
         where the PSD for a channel has large spike(s) in order to suppress echoes 
-        elsewhere in the trace.
+        elsewhere in the trace. Each value in the list specifies this attribute for each channel.
     ofamp_nodelay_lowfreqchi2 : bool
         Boolean flag for whether or not to calculate the low frequency chi-squared for 
         the optimum filter fit with no time shifting.
-    do_ofamp_unconstrained : bool
+    do_ofamp_unconstrained : list of bool
         Boolean flag for whether or not to do the optimum filter fit with unconstrained time
-        shifting.
-    do_ofamp_unconstrained_smooth : bool
+        shifting. Each value in the list specifies this attribute for each channel.
+    do_ofamp_unconstrained_smooth : list of bool
         Boolean flag for whether or not the optimum filter fit with unconstrained time
         shifting should be calculated with a smoothed PSD. Useful in the case 
         where the PSD for a channel has large spike(s) in order to suppress echoes 
-        elsewhere in the trace.
+        elsewhere in the trace. Each value in the list specifies this attribute for each channel.
     ofamp_unconstrained_lowfreqchi2 : bool
         Boolean flag for whether or not to calculate the low frequency chi-squared for 
         the optimum filter fit with unconstrained time shifting.
-    ofamp_unconstrained_pulse_constraint : int, list of int
+    ofamp_unconstrained_pulse_constraint : list of int
         Sets a constraint on the direction of the fitted pulse. If 0, then no constraint on the 
         pulse direction is set. If 1, then a positive pulse constraint is set for all fits. 
         If -1, then a negative pulse constraint is set for all fits. If any other value, then
-        an ValueError will be raised.
-    do_ofamp_constrained : bool
+        an ValueError will be raised. Each value in the list specifies this attribute for each channel.
+    do_ofamp_constrained : list of bool
         Boolean flag for whether or not to do the optimum filter fit with constrained time
-        shifting.
-    do_ofamp_constrained_smooth : bool
+        shifting. Each value in the list specifies this attribute for each channel.
+    do_ofamp_constrained_smooth : list of bool
         Boolean flag for whether or not the optimum filter fit with constrained time
         shifting should be calculated with a smoothed PSD. Useful in the case 
         where the PSD for a channel has large spike(s) in order to suppress echoes 
-        elsewhere in the trace.
+        elsewhere in the trace. Each value in the list specifies this attribute for each channel.
     ofamp_constrained_lowfreqchi2 : bool
         Boolean flag for whether or not to calculate the low frequency chi-squared for 
         the optimum filter fit with constrained time shifting.
-    ofamp_constrained_nconstrain : list
+    ofamp_constrained_nconstrain : list of int
         The length of the window (in bins), centered on the middle of the trace, to constrain 
-        the possible time shift values to when doing the optimum filter fit with constrained time shifting.
-    ofamp_constrained_pulse_constraint : int, list of int
+        the possible time shift values to when doing the optimum filter fit with constrained time shifting. 
+        Each value in the list specifies this attribute for each channel.
+    ofamp_constrained_pulse_constraint : list of int
         Sets a constraint on the direction of the fitted pulse. If 0, then no constraint on the 
         pulse direction is set. If 1, then a positive pulse constraint is set for all fits. 
         If -1, then a negative pulse constraint is set for all fits. If any other value, then
-        an ValueError will be raised.
-    do_ofamp_pileup : bool
-        Boolean flag for whether or not to do the pileup optimum filter fit.
-    do_ofamp_pileup_smooth : bool
+        an ValueError will be raised. Each value in the list specifies this attribute for each channel.
+    do_ofamp_pileup : list of bool
+        Boolean flag for whether or not to do the pileup optimum filter fit. Each value in the list specifies 
+        this attribute for each channel.
+    do_ofamp_pileup_smooth : list of bool
         Boolean flag for whether or not the pileup optimum filter fit should be calculated 
         with a smoothed PSD. Useful in the case where the PSD for a channel has large spike(s) 
-        in order to suppress echoes elsewhere in the trace.
-    ofamp_pileup_nconstrain : list
+        in order to suppress echoes elsewhere in the trace. Each value in the list specifies this
+        attribute for each channel.
+    ofamp_pileup_nconstrain : list of int
         The length of the window (in bins), centered on the middle of the trace, outside of which to 
-        constrain the possible time shift values to when searching for a pileup pulse using ofamp_pileup.
-    ofamp_pileup_pulse_constraint : int, list of int
+        constrain the possible time shift values to when searching for a pileup pulse using ofamp_pileup. Each 
+        value in the list specifies this attribute for each channel.
+    ofamp_pileup_pulse_constraint : list of int
         Sets a constraint on the direction of the fitted pulse. If 0, then no constraint on the 
         pulse direction is set. If 1, then a positive pulse constraint is set for all fits. 
         If -1, then a negative pulse constraint is set for all fits. If any other value, then
-        an ValueError will be raised.
-    do_chi2_nopulse : bool
-        Boolean flag for whether or not to calculate the chi^2 for no pulse.
-    do_chi2_nopulse_smooth : bool
+        an ValueError will be raised. Each value in the list specifies this attribute for each channel.
+    do_chi2_nopulse : list of bool
+        Boolean flag for whether or not to calculate the chi^2 for no pulse. Each value in the list specifies
+        this attribute for each channel.
+    do_chi2_nopulse_smooth : list of bool
         Boolean flag for whether or not the chi^2 for no pulse should be calculated 
         with a smoothed PSD. Useful in the case where the PSD for a channel has large 
-        spike(s) in order to suppress echoes elsewhere in the trace.
-    do_chi2_lowfreq : bool
-        Boolean flag for whether or not to calculate the low frequency chi^2 for any of the fits.
-    chi2_lowfreq_fcutoff : list
-        The frequency cutoff for the calculation of the low frequency chi^2, units of Hz.
-    do_ofamp_baseline : bool
-        Boolean flag for whether or not to do the optimum filter fit with fixed baseline.
-    do_ofamp_baseline_smooth : bool
+        spike(s) in order to suppress echoes elsewhere in the trace. Each value in the list specifies this 
+        attribute for each channel.
+    do_chi2_lowfreq : list of bool
+        Boolean flag for whether or not to calculate the low frequency chi^2 for any of the fits. Each value 
+        in the list specifies this attribute for each channel.
+    chi2_lowfreq_fcutoff : list of int
+        The frequency cutoff for the calculation of the low frequency chi^2, units of Hz. Each value in the 
+        list specifies this attribute for each channel.
+    do_ofamp_baseline : list of bool
+        Boolean flag for whether or not to do the optimum filter fit with fixed baseline. Each value in 
+        the list specifies this attribute for each channel.
+    do_ofamp_baseline_smooth : list of bool
         Boolean flag for whether or not the optimum filter fit with fixed baseline
         should be calculated with a smoothed PSD. Useful in the case where the PSD for a 
-        channel has large spike(s) in order to suppress echoes elsewhere in the trace.
-    ofamp_baseline_nconstrain : list
+        channel has large spike(s) in order to suppress echoes elsewhere in the trace. Each value in the 
+        list specifies this attribute for each channel.
+    ofamp_baseline_nconstrain : list of int
         The length of the window (in bins), centered on the middle of the trace, to constrain 
-        the possible time shift values to when doing the optimum filter fit with fixed baseline.
-    ofamp_baseline_pulse_constraint : int, list of int
+        the possible time shift values to when doing the optimum filter fit with fixed baseline. Each 
+        value in the list specifies this attribute for each channel.
+    ofamp_baseline_pulse_constraint : list of int
         Sets a constraint on the direction of the fitted pulse. If 0, then no constraint on the 
         pulse direction is set. If 1, then a positive pulse constraint is set for all fits. 
         If -1, then a negative pulse constraint is set for all fits. If any other value, then
-        an ValueError will be raised.
-    do_baseline : bool
-        Boolean flag for whether or not to calculate the DC baseline for each trace.
-    baseline_indbasepre : int
-        The number of indices up to which a trace should be averaged to determine the baseline.
-    do_integral : bool
-        Boolean flag for whether or not to calculate the baseline-subtracted integral of each trace.
-    indstart_integral : int, list of int
+        an ValueError will be raised. Each value in the list specifies this attribute for each channel.
+    do_baseline : list of bool
+        Boolean flag for whether or not to calculate the DC baseline for each trace. Each value in the 
+        list specifies this attribute for each channel.
+    baseline_indbasepre : list of int
+        The number of indices up to which a trace should be averaged to determine the baseline. Each value
+        in the list specifies this attribute for each channel.
+    do_integral : list of bool
+        Boolean flag for whether or not to calculate the baseline-subtracted integral of each trace. Each value
+        in the list specifies this attribute for each channel.
+    indstart_integral : list of int
         The index at which the integral should start being calculated from in order to reduce noise by 
-        truncating the beginning of the trace. Default is 16000.
-    indstop_integral : int, list of int
+        truncating the beginning of the trace. Default is 1/3 of the trace length. Each value in the 
+        list specifies this attribute for each channel.
+    indstop_integral : list of int
         The index at which the integral should be calculated up to in order to reduce noise by 
-        truncating the rest of the trace. Default is 20000.
-    do_ofamp_shifted : bool
+        truncating the rest of the trace. Default is 2/3 of the trace length. Each value in the list
+        specifies this attribute for each channel.
+    do_ofamp_shifted : list of bool
         Boolean flag for whether or not the shifted optimum filter fit should be calculated for
-        the non-trigger channels. If set to True, then self.trigger must have been set to a value.
-    do_ofamp_shifted_smooth : bool
+        the non-trigger channels. If set to True, then self.trigger must have been set to a value. Each 
+        value in the list specifies this attribute for each channel.
+    do_ofamp_shifted_smooth : list of bool
         Boolean flag for whether or not the shifted optimum filter fit should be calculated 
         with a smoothed PSD. Useful in the case where the PSD for a channel has large spike(s) 
-        in order to suppress echoes elsewhere in the trace.
+        in order to suppress echoes elsewhere in the trace. Each value in the list specifies this
+        attribute for each channel.
     shifted_fit : str
         String specifying which fit that the time shift should be pulled from if the shifted
         optimum filter fit will be calculated. Should be "nodelay", "constrained", or "unconstrained",
@@ -161,14 +179,14 @@ class SetupRQ(object):
     t0_shifted : ndarray
         Attribute used to save the times to shift the non-trigger channels. Only used if `do_ofamp_shifted`
         is True.
-    do_optimumfilters : bool
+    do_optimumfilters : list of bool
         Boolean flag for whether or not any of the optimum filters will be calculated. If only
         calculating non-OF-related RQs, then this will be False, and processing time will not
-        be spent on initializing the OF.
-    do_optimumfilters_smooth : bool
+        be spent on initializing the OF. Each value in the list specifies this attribute for each channel.
+    do_optimumfilters_smooth : list of bool
         Boolean flag for whether or not any of the smoothed-PDS optimum filters will be calculated. 
         If only calculating non-OF-related RQs, then this will be False, and processing time will not
-        be spent on initializing the OF.
+        be spent on initializing the OF. Each value in the list specifies this attribute for each channel.
     
     """
     
@@ -211,6 +229,9 @@ class SetupRQ(object):
             
         if not isinstance(psds, list):
             psds = [psds]
+            
+        if len(templates) != len(psds):
+            raise ValueError("Different numbers of templates and psds were inputted")
         
         if len(templates[0]) != len(psds[0]):
             raise ValueError("templates and psds should have the same length")
@@ -245,56 +266,56 @@ class SetupRQ(object):
         else:
             self.calcsum=True
         
-        self.do_ofamp_nodelay = True
-        self.do_ofamp_nodelay_smooth = False
+        self.do_ofamp_nodelay = [True]*self.nchan
+        self.do_ofamp_nodelay_smooth = [False]*self.nchan
         self.ofamp_nodelay_lowfreqchi2 = False
         
-        self.do_ofamp_unconstrained = True
-        self.do_ofamp_unconstrained_smooth = False
+        self.do_ofamp_unconstrained = [True]*self.nchan
+        self.do_ofamp_unconstrained_smooth = [False]*self.nchan
         self.ofamp_unconstrained_lowfreqchi2 = False
         self.ofamp_unconstrained_pulse_constraint = [0]*self.nchan
         
-        self.do_ofamp_constrained = True
-        self.do_ofamp_constrained_smooth = False
+        self.do_ofamp_constrained = [True]*self.nchan
+        self.do_ofamp_constrained_smooth = [False]*self.nchan
         self.ofamp_constrained_lowfreqchi2 = True
         self.ofamp_constrained_nconstrain = [80]*self.nchan
         self.ofamp_constrained_pulse_constraint = [0]*self.nchan
         
-        self.do_ofamp_pileup = True
-        self.do_ofamp_pileup_smooth = False
+        self.do_ofamp_pileup = [True]*self.nchan
+        self.do_ofamp_pileup_smooth = [False]*self.nchan
         self.ofamp_pileup_nconstrain = [80]*self.nchan
         self.ofamp_pileup_pulse_constraint = [0]*self.nchan
         
-        self.do_chi2_nopulse = True
-        self.do_chi2_nopulse_smooth = False
+        self.do_chi2_nopulse = [True]*self.nchan
+        self.do_chi2_nopulse_smooth = [False]*self.nchan
         
-        self.do_chi2_lowfreq = True
+        self.do_chi2_lowfreq = [True]*self.nchan
         self.chi2_lowfreq_fcutoff = [10000]*self.nchan
         
-        self.do_ofamp_baseline = False
-        self.do_ofamp_baseline_smooth = False
+        self.do_ofamp_baseline = [False]*self.nchan
+        self.do_ofamp_baseline_smooth = [False]*self.nchan
         self.ofamp_baseline_nconstrain = [80]*self.nchan
         self.ofamp_baseline_pulse_constraint = [0]*self.nchan
         
-        self.do_baseline = True
-        self.baseline_indbasepre = [16000]*self.nchan
+        self.do_baseline = [True]*self.nchan
+        self.baseline_indbasepre = [len(self.templates[0])//3]*self.nchan
         
-        self.do_integral = True
-        self.indstart_integral = [16000]*self.nchan
-        self.indstop_integral = [20000]*self.nchan
+        self.do_integral = [True]*self.nchan
+        self.indstart_integral = [len(self.templates[0])//3]*self.nchan
+        self.indstop_integral = [2*len(self.templates[0])//3]*self.nchan
         
-        self.do_ofamp_shifted = False
-        self.do_ofamp_shifted_smooth = False
+        self.do_ofamp_shifted = [False]*self.nchan
+        self.do_ofamp_shifted_smooth = [False]*self.nchan
         self.which_fit = "constrained"
         self.t0_shifted = None
         
-        self.do_maxmin = True
+        self.do_maxmin = [True]*self.nchan
         self.use_min = [False]*self.nchan
         self.indstart_maxmin = [0]*self.nchan
         self.indstop_maxmin = [len(self.templates[0])]*self.nchan
         
-        self.do_optimumfilters = True
-        self.do_optimumfilters_smooth = False
+        self.do_optimumfilters = [True]*self.nchan
+        self.do_optimumfilters_smooth = [False]*self.nchan
         
     def _check_of(self):
         """
@@ -302,41 +323,45 @@ class SetupRQ(object):
         
         """
         
-        if self.do_ofamp_nodelay:
-            self.do_optimumfilters = True
-        elif self.do_ofamp_unconstrained:
-            self.do_optimumfilters = True
-        elif self.do_ofamp_constrained:
-            self.do_optimumfilters = True
-        elif self.do_ofamp_pileup:
-            self.do_optimumfilters = True
-        elif self.do_chi2_nopulse:
-            self.do_optimumfilters = True
-        elif self.do_chi2_lowfreq:
-            self.do_optimumfilters = True
-        elif self.do_ofamp_baseline:
-            self.do_optimumfilters = True
-        elif self.do_ofamp_shifted:
-            self.do_optimumfilters = True
-        else:
-            self.do_optimumfilters = False
+        do_optimumfilters = [False]*self.nchan
+        
+        if any(self.do_ofamp_nodelay):
+            do_optimumfilters = [ii or jj for ii, jj in zip(do_optimumfilters, self.do_ofamp_nodelay)]
+        if any(self.do_ofamp_unconstrained):
+            do_optimumfilters = [ii or jj for ii, jj in zip(do_optimumfilters, self.do_ofamp_unconstrained)]
+        if any(self.do_ofamp_constrained):
+            do_optimumfilters = [ii or jj for ii, jj in zip(do_optimumfilters, self.do_ofamp_constrained)]
+        if any(self.do_ofamp_pileup):
+            do_optimumfilters = [ii or jj for ii, jj in zip(do_optimumfilters, self.do_ofamp_pileup)]
+        if any(self.do_chi2_nopulse):
+            do_optimumfilters = [ii or jj for ii, jj in zip(do_optimumfilters, self.do_chi2_nopulse)]
+        if any(self.do_chi2_lowfreq):
+            do_optimumfilters = [ii or jj for ii, jj in zip(do_optimumfilters, self.do_chi2_lowfreq)]
+        if any(self.do_ofamp_baseline):
+            do_optimumfilters = [ii or jj for ii, jj in zip(do_optimumfilters, self.do_ofamp_baseline)]
+        if any(self.do_ofamp_shifted):
+            do_optimumfilters = [ii or jj for ii, jj in zip(do_optimumfilters, self.do_ofamp_shifted)]
+        
+        self.do_optimumfilters = do_optimumfilters
+        
+        do_optimumfilters_smooth = [False]*self.nchan
             
-        if self.do_ofamp_nodelay_smooth:
-            self.do_optimumfilters_smooth = True
-        elif self.do_ofamp_unconstrained_smooth:
-            self.do_optimumfilters_smooth = True
-        elif self.do_ofamp_constrained_smooth:
-            self.do_optimumfilters_smooth = True
-        elif self.do_ofamp_pileup_smooth:
-            self.do_optimumfilters_smooth = True
-        elif self.do_chi2_nopulse_smooth:
-            self.do_optimumfilters_smooth = True
-        elif self.do_ofamp_baseline_smooth:
-            self.do_optimumfilters_smooth = True
-        elif self.do_ofamp_shifted_smooth:
-            self.do_optimumfilters_smooth = True
-        else:
-            self.do_optimumfilters_smooth = False
+        if any(self.do_ofamp_nodelay_smooth):
+            do_optimumfilters_smooth = [ii or jj for ii, jj in zip(do_optimumfilters_smooth, self.do_ofamp_nodelay_smooth)]
+        if any(self.do_ofamp_unconstrained_smooth):
+            do_optimumfilters_smooth = [ii or jj for ii, jj in zip(do_optimumfilters_smooth, self.do_ofamp_unconstrained_smooth)]
+        if any(self.do_ofamp_constrained_smooth):
+            do_optimumfilters_smooth = [ii or jj for ii, jj in zip(do_optimumfilters_smooth, self.do_ofamp_constrained_smooth)]
+        if any(self.do_ofamp_pileup_smooth):
+            do_optimumfilters_smooth = [ii or jj for ii, jj in zip(do_optimumfilters_smooth, self.do_ofamp_pileup_smooth)]
+        if any(self.do_chi2_nopulse_smooth):
+            do_optimumfilters_smooth = [ii or jj for ii, jj in zip(do_optimumfilters_smooth, self.do_chi2_nopulse_smooth)]
+        if any(self.do_ofamp_baseline_smooth):
+            do_optimumfilters_smooth = [ii or jj for ii, jj in zip(do_optimumfilters_smooth, self.do_ofamp_baseline_smooth)]
+        if any(self.do_ofamp_shifted_smooth):
+            do_optimumfilters_smooth = [ii or jj for ii, jj in zip(do_optimumfilters_smooth, self.do_ofamp_shifted_smooth)]
+            
+        self.do_optimumfilters_smooth = do_optimumfilters_smooth
         
     def _check_arg_length(self, **kwargs):
         """
@@ -419,10 +444,10 @@ class SetupRQ(object):
         
         Parameters
         ----------
-        lgcrun : bool, optional
+        lgcrun : bool, list of bool, optional
             Boolean flag for whether or not the optimum filter fit with no time
             shifting should be calculated.
-        lgcrun_smooth : bool, optional
+        lgcrun_smooth : bool, list of bool, optional
             Boolean flag for whether or not the optimum filter fit with no time
             shifting should be calculated with a smoothed PSD. Useful in the case 
             where the PSD for a channel has large spike(s) in order to suppress echoes 
@@ -433,6 +458,8 @@ class SetupRQ(object):
             using the adjust_chi2_lowfreq method.
         
         """
+        
+        lgcrun, lgcrun_smooth = self._check_arg_length(lgcrun=lgcrun, lgcrun_smooth=lgcrun_smooth)
         
         self.do_ofamp_nodelay = lgcrun
         self.do_ofamp_nodelay_smooth = lgcrun_smooth
@@ -448,10 +475,10 @@ class SetupRQ(object):
         
         Parameters
         ----------
-        lgcrun : bool, optional
+        lgcrun : bool, list of bool, optional
             Boolean flag for whether or not the optimum filter fit with unconstrained 
             time shifting should be calculated.
-        lgcrun_smooth : bool, optional
+        lgcrun_smooth : bool, list of bool, optional
             Boolean flag for whether or not the optimum filter fit with unconstrained time
             shifting should be calculated with a smoothed PSD. Useful in the case 
             where the PSD for a channel has large spike(s) in order to suppress echoes 
@@ -460,7 +487,7 @@ class SetupRQ(object):
             Boolean flag for whether or not the low frequency chi^2 of this fit 
             should be calculated. The low frequency chi^2 calculation should be adjusted
             using the adjust_chi2_lowfreq method. Default is False.
-        pulse_direction_constraint : int, optional
+        pulse_direction_constraint : int, list of int, optional
             Sets a constraint on the direction of the fitted pulse. If 0, then no constraint on the 
             pulse direction is set. If 1, then a positive pulse constraint is set for all fits. 
             If -1, then a negative pulse constraint is set for all fits. If any other value, then
@@ -468,7 +495,9 @@ class SetupRQ(object):
         
         """
         
-        pulse_direction_constraint = self._check_arg_length(pulse_direction_constraint=pulse_direction_constraint)
+        lgcrun, lgcrun_smooth, pulse_direction_constraint = self._check_arg_length(lgcrun=lgcrun,
+                                                                                   lgcrun_smooth=lgcrun_smooth,
+                                                            pulse_direction_constraint=pulse_direction_constraint)
         
         self.do_ofamp_unconstrained = lgcrun
         self.do_ofamp_unconstrained_smooth = lgcrun_smooth
@@ -486,10 +515,10 @@ class SetupRQ(object):
         
         Parameters
         ----------
-        lgcrun : bool, optional
+        lgcrun : bool, list of bool, optional
             Boolean flag for whether or not the optimum filter fit with constrained 
             time shifting should be calculated.
-        lgcrun_smooth : bool, optional
+        lgcrun_smooth : bool, list of bool, optional
             Boolean flag for whether or not the optimum filter fit with constrained time
             shifting should be calculated with a smoothed PSD. Useful in the case 
             where the PSD for a channel has large spike(s) in order to suppress echoes 
@@ -504,7 +533,7 @@ class SetupRQ(object):
             fit with constrained time shifting. Can be set to a list of values, if the 
             constrain window should be different for each channel. The length of the list should
             be the same length as the number of channels.
-        pulse_direction_constraint : int, optional
+        pulse_direction_constraint : int, list of int, optional
             Sets a constraint on the direction of the fitted pulse. If 0, then no constraint on the 
             pulse direction is set. If 1, then a positive pulse constraint is set for all fits. 
             If -1, then a negative pulse constraint is set for all fits. If any other value, then
@@ -512,7 +541,9 @@ class SetupRQ(object):
         
         """
         
-        nconstrain, pulse_direction_constraint = self._check_arg_length(nconstrain=nconstrain, 
+        lgcrun, lgcrun_smooth, nconstrain, pulse_direction_constraint = self._check_arg_length(lgcrun=lgcrun,
+                                                                                               lgcrun_smooth=lgcrun_smooth,
+                                                                                               nconstrain=nconstrain, 
                                                                         pulse_direction_constraint=pulse_direction_constraint)
         
         self.do_ofamp_constrained = lgcrun
@@ -532,10 +563,10 @@ class SetupRQ(object):
         
         Parameters
         ----------
-        lgcrun : bool, optional
+        lgcrun : bool, list of bool, optional
             Boolean flag for whether or not the optimum filter fit with fixed baseline 
             should be calculated.
-        lgcrun_smooth : bool, optional
+        lgcrun_smooth : bool, list of bool, optional
             Boolean flag for whether or not the optimum filter fit with fixed baseline
             should be calculated with a smoothed PSD. Useful in the case where the PSD for a 
             channel has large spike(s) in order to suppress echoes elsewhere in the trace.
@@ -545,7 +576,7 @@ class SetupRQ(object):
             fit with fixed baseline. Can be set to a list of values, if the 
             constrain window should be different for each channel. The length of the list should
             be the same length as the number of channels.
-        pulse_direction_constraint : int, optional
+        pulse_direction_constraint : int, list of int, optional
             Sets a constraint on the direction of the fitted pulse. If 0, then no constraint on the 
             pulse direction is set. If 1, then a positive pulse constraint is set for all fits. 
             If -1, then a negative pulse constraint is set for all fits. If any other value, then
@@ -553,7 +584,9 @@ class SetupRQ(object):
         
         """
         
-        nconstrain, pulse_direction_constraint = self._check_arg_length(nconstrain=nconstrain, 
+        lgcrun, lgcrun_smooth, nconstrain, pulse_direction_constraint = self._check_arg_length(lgcrun=lgcrun,
+                                                                                               lgcrun_smooth=lgcrun_smooth,
+                                                                                               nconstrain=nconstrain, 
                                                                         pulse_direction_constraint=pulse_direction_constraint)
         
         self.do_ofamp_baseline = lgcrun
@@ -571,9 +604,9 @@ class SetupRQ(object):
         
         Parameters
         ----------
-        lgcrun : bool, optional
+        lgcrun : bool, list of bool, optional
             Boolean flag for whether or not the pileup optimum filter fit should be calculated.
-        lgcrun_smooth : bool, optional
+        lgcrun_smooth : bool, list of bool, optional
             Boolean flag for whether or not the pileup optimum filter fit should be calculated 
             with a smoothed PSD. Useful in the case where the PSD for a channel has large spike(s) 
             in order to suppress echoes elsewhere in the trace.
@@ -583,7 +616,7 @@ class SetupRQ(object):
             pileup pulse using ofamp_pileup. Can be set to a list of values, if the constrain 
             window should be different for each channel. The length of the list should
             be the same length as the number of channels.
-        pulse_direction_constraint : int, optional
+        pulse_direction_constraint : int, list of int, optional
             Sets a constraint on the direction of the fitted pulse. If 0, then no constraint on the 
             pulse direction is set. If 1, then a positive pulse constraint is set for all fits. 
             If -1, then a negative pulse constraint is set for all fits. If any other value, then
@@ -591,7 +624,9 @@ class SetupRQ(object):
         
         """
         
-        nconstrain, pulse_direction_constraint = self._check_arg_length(nconstrain=nconstrain, 
+        lgcrun, lgcrun_smooth, nconstrain, pulse_direction_constraint = self._check_arg_length(lgcrun=lgcrun,
+                                                                                               lgcrun_smooth=lgcrun_smooth,
+                                                                                               nconstrain=nconstrain, 
                                                                         pulse_direction_constraint=pulse_direction_constraint)
         
         self.do_ofamp_pileup = lgcrun
@@ -608,14 +643,16 @@ class SetupRQ(object):
         
         Parameters
         ----------
-        lgcrun : bool, optional
+        lgcrun : bool, list of bool, optional
             Boolean flag for whether or not to calculate the chi^2 for no pulse.
-        lgcrun_smooth : bool, optional
+        lgcrun_smooth : bool, list of bool, optional
             Boolean flag for whether or not the chi^2 for no pulse should be calculated 
             with a smoothed PSD. Useful in the case where the PSD for a channel has large 
             spike(s) in order to suppress echoes elsewhere in the trace.
         
         """
+        
+        lgcrun, lgcrun_smooth = self._check_arg_length(lgcrun=lgcrun, lgcrun_smooth=lgcrun_smooth)
         
         self.do_chi2_nopulse = lgcrun
         self.do_chi2_nopulse_smooth = lgcrun_smooth
@@ -628,7 +665,7 @@ class SetupRQ(object):
         
         Parameters
         ----------
-        lgcrun : bool, optional
+        lgcrun : bool, list of bool, optional
             Boolean flag for whether or not the low frequency chi^2 should be calculated
             for any of the optimum filter fits.
         fcutoff : float, list of float, optional
@@ -639,7 +676,7 @@ class SetupRQ(object):
             
         """
         
-        fcutoff = self._check_arg_length(fcutoff=fcutoff)
+        lgcrun, fcutoff = self._check_arg_length(lgcrun=lgcrun, fcutoff=fcutoff)
             
         self.do_chi2_lowfreq = lgcrun
         self.chi2_lowfreq_fcutoff = fcutoff
@@ -652,7 +689,7 @@ class SetupRQ(object):
         
         Parameters
         ----------
-        lgcrun : bool, optional
+        lgcrun : bool, list of bool, optional
             Boolean flag for whether or not the DC baseline should be calculated. It is highly
             recommended to set this to true if the integral will be calculated, so that the
             baseline can be subtracted.
@@ -664,9 +701,9 @@ class SetupRQ(object):
         """
         
         if indbasepre is None:
-            indbasepre = len(templates[0])//3
+            indbasepre = len(self.templates[0])//3
         
-        indbasepre = self._check_arg_length(indbasepre=indbasepre)
+        lgcrun, indbasepre = self._check_arg_length(lgcrun=lgcrun, indbasepre=indbasepre)
             
         self.do_baseline = lgcrun
         self.baseline_indbasepre = indbasepre
@@ -677,7 +714,7 @@ class SetupRQ(object):
         
         Parameters
         ----------
-        lgcrun : bool, optional
+        lgcrun : bool, list of bool, optional
             Boolean flag for whether or not the integral should be calculated. If self.do_baseline
             is True, then the baseline is subtracted from the integral. If self.do_baseline is False,
             then the baseline is not subtracted. It is recommended that the baseline should be subtracted.
@@ -691,12 +728,12 @@ class SetupRQ(object):
         """
         
         if indstart is None:
-            indstart = len(templates[0])//3
+            indstart = len(self.templates[0])//3
             
         if indstop is None:
-            indstop = 2*len(templates[0])//3
+            indstop = 2*len(self.templates[0])//3
         
-        indstart, indstop = self._check_arg_length(indstart=indstart, indstop=indstop)
+        lgcrun, indstart, indstop = self._check_arg_length(lgcrun=lgcrun, indstart=indstart, indstop=indstop)
         
         self.do_integral = lgcrun
         self.indstart_integral = indstart
@@ -708,7 +745,7 @@ class SetupRQ(object):
         
         Parameters
         ----------
-        lgcrun : bool, optional
+        lgcrun : bool, list of bool, optional
             Boolean flag for whether or not the maximum (or minimum) of the trace should be calculated.
         use_min : bool, list of bool, optional
             Whether or not to use the maximum or the minimum when calculating maxmin. If True, then the
@@ -728,7 +765,8 @@ class SetupRQ(object):
         if indstop is None:
             indstop = len(self.templates[0])
             
-        use_min, indstart, indstop = self._check_arg_length(use_min=use_min, indstart=indstart, indstop=indstop)
+        lgcrun, use_min, indstart, indstop = self._check_arg_length(lgcrun=lgcrun, use_min=use_min, 
+                                                                    indstart=indstart, indstop=indstop)
         
         self.do_maxmin = lgcrun
         self.use_min = use_min
@@ -755,6 +793,8 @@ class SetupRQ(object):
             is "constrained".
             
         """
+        
+        lgcrun, lgcrun_smooth = self._check_arg_length(lgcrun=lgcrun, lgcrun_smooth=lgcrun_smooth)
         
         self.do_ofamp_shifted = lgcrun
         
@@ -831,13 +871,13 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
     
     fs = setup.fs
     
-    if setup.do_baseline:
+    if setup.do_baseline[chan_num]:
         baseline = np.mean(signal[:, :setup.baseline_indbasepre[chan_num]], axis=-1)
         rq_dict[f'baseline_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'baseline_{chan}{det}'][readout_inds] = baseline
     
-    if setup.do_integral:
-        if setup.do_baseline:
+    if setup.do_integral[chan_num]:
+        if setup.do_baseline[chan_num]:
             integral = np.trapz(signal[:, setup.indstart_integral[chan_num]:setup.indstop_integral[chan_num]]\
                                 - baseline[:, np.newaxis], axis=-1)/fs
         else:
@@ -845,7 +885,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
         rq_dict[f'integral_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'integral_{chan}{det}'][readout_inds] = integral
         
-    if setup.do_maxmin:
+    if setup.do_maxmin[chan_num]:
         if setup.use_min[chan_num]:
             maxmin = np.amin(signal[:, setup.indstart_maxmin[chan_num]:setup.indstop_maxmin[chan_num]], axis=-1)
         else:
@@ -854,19 +894,19 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
         rq_dict[f'maxmin_{chan}{det}'][readout_inds] = maxmin
     
     # initialize variables for the various OFs
-    if setup.do_chi2_nopulse:
+    if setup.do_chi2_nopulse[chan_num]:
         chi0 = np.zeros(len(signal))
-    if setup.do_chi2_nopulse_smooth:
+    if setup.do_chi2_nopulse_smooth[chan_num]:
         chi0_smooth = np.zeros(len(signal))
     
-    if setup.do_ofamp_nodelay:
+    if setup.do_ofamp_nodelay[chan_num]:
         amp_nodelay = np.zeros(len(signal))
         chi2_nodelay = np.zeros(len(signal))
-    if setup.do_ofamp_nodelay_smooth:
+    if setup.do_ofamp_nodelay_smooth[chan_num]:
         amp_nodelay_smooth = np.zeros(len(signal))
         chi2_nodelay_smooth = np.zeros(len(signal))
     
-    if setup.do_ofamp_unconstrained:
+    if setup.do_ofamp_unconstrained[chan_num]:
         amp_noconstrain = np.zeros(len(signal))
         t0_noconstrain = np.zeros(len(signal))
         chi2_noconstrain = np.zeros(len(signal))
@@ -874,12 +914,12 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
             amp_noconstrain_pcon = np.zeros(len(signal))
             t0_noconstrain_pcon  = np.zeros(len(signal))
             chi2_noconstrain_pcon  = np.zeros(len(signal))
-    if setup.do_ofamp_unconstrained_smooth:
+    if setup.do_ofamp_unconstrained_smooth[chan_num]:
         amp_noconstrain_smooth = np.zeros(len(signal))
         t0_noconstrain_smooth = np.zeros(len(signal))
         chi2_noconstrain_smooth = np.zeros(len(signal))
     
-    if setup.do_ofamp_constrained:
+    if setup.do_ofamp_constrained[chan_num]:
         amp_constrain = np.zeros(len(signal))
         t0_constrain = np.zeros(len(signal))
         chi2_constrain = np.zeros(len(signal))
@@ -887,12 +927,12 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
             amp_constrain_pcon = np.zeros(len(signal))
             t0_constrain_pcon = np.zeros(len(signal))
             chi2_constrain_pcon = np.zeros(len(signal))
-    if setup.do_ofamp_constrained_smooth:
+    if setup.do_ofamp_constrained_smooth[chan_num]:
         amp_constrain_smooth = np.zeros(len(signal))
         t0_constrain_smooth = np.zeros(len(signal))
         chi2_constrain_smooth = np.zeros(len(signal))
     
-    if setup.do_ofamp_pileup:
+    if setup.do_ofamp_pileup[chan_num]:
         amp_pileup = np.zeros(len(signal))
         t0_pileup = np.zeros(len(signal))
         chi2_pileup = np.zeros(len(signal))
@@ -900,12 +940,12 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
             amp_pileup_pcon = np.zeros(len(signal))
             t0_pileup_pcon = np.zeros(len(signal))
             chi2_pileup_pcon = np.zeros(len(signal))
-    if setup.do_ofamp_pileup_smooth:
+    if setup.do_ofamp_pileup_smooth[chan_num]:
         amp_pileup_smooth = np.zeros(len(signal))
         t0_pileup_smooth = np.zeros(len(signal))
         chi2_pileup_smooth = np.zeros(len(signal))
     
-    if setup.do_ofamp_baseline:
+    if setup.do_ofamp_baseline[chan_num]:
         amp_baseline = np.zeros(len(signal))
         t0_baseline = np.zeros(len(signal))
         chi2_baseline = np.zeros(len(signal))
@@ -913,12 +953,12 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
             amp_baseline_pcon = np.zeros(len(signal))
             t0_baseline_pcon = np.zeros(len(signal))
             chi2_baseline_pcon = np.zeros(len(signal))
-    if setup.do_ofamp_baseline_smooth:
+    if setup.do_ofamp_baseline_smooth[chan_num]:
         amp_baseline_smooth = np.zeros(len(signal))
         t0_baseline_smooth = np.zeros(len(signal))
         chi2_baseline_smooth = np.zeros(len(signal))
         
-    if setup.do_chi2_lowfreq:
+    if setup.do_chi2_lowfreq[chan_num]:
         if setup.ofamp_nodelay_lowfreqchi2:
             chi2low_nodelay = np.zeros(len(signal))
         if setup.ofamp_unconstrained_lowfreqchi2:
@@ -927,49 +967,49 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
             chi2low_constrain = np.zeros(len(signal))
     
     # run the OF class for each trace
-    if setup.do_optimumfilters:
+    if setup.do_optimumfilters[chan_num]:
         OF = qp.OptimumFilter(signal[0], template, psd, fs)
-    if setup.do_optimumfilters_smooth:
+    if setup.do_optimumfilters_smooth[chan_num]:
         psd_smooth = qp.smooth_psd(psd)
         OF_smooth = qp.OptimumFilter(signal[0], template, psd_smooth, fs)
     
     for jj, s in enumerate(signal):
         if jj!=0:
-            if setup.do_optimumfilters:
+            if setup.do_optimumfilters[chan_num]:
                 OF.update_signal(s)
-            if setup.do_optimumfilters_smooth:
+            if setup.do_optimumfilters_smooth[chan_num]:
                 OF_smooth.update_signal(s)
         
-        if setup.do_chi2_nopulse:
+        if setup.do_chi2_nopulse[chan_num]:
             chi0[jj] = OF.chi2_nopulse()
             
-        if setup.do_chi2_nopulse_smooth:
+        if setup.do_chi2_nopulse_smooth[chan_num]:
             chi0_smooth[jj] = OF_smooth.chi2_nopulse()
         
-        if setup.do_ofamp_nodelay:
+        if setup.do_ofamp_nodelay[chan_num]:
             amp_nodelay[jj], chi2_nodelay[jj] = OF.ofamp_nodelay()
             
-        if setup.do_ofamp_nodelay_smooth:
+        if setup.do_ofamp_nodelay_smooth[chan_num]:
             amp_nodelay_smooth[jj], chi2_nodelay_smooth[jj] = OF_smooth.ofamp_nodelay()
         
-        if setup.ofamp_nodelay_lowfreqchi2 and setup.do_chi2_lowfreq:
+        if setup.ofamp_nodelay_lowfreqchi2 and setup.do_chi2_lowfreq[chan_num]:
             chi2low_nodelay[jj] = OF.chi2_lowfreq(amp_nodelay[jj], 0, 
                                           fcutoff=setup.chi2_lowfreq_fcutoff[chan_num])
         
-        if setup.do_ofamp_unconstrained:
+        if setup.do_ofamp_unconstrained[chan_num]:
             amp_noconstrain[jj], t0_noconstrain[jj], chi2_noconstrain[jj] = OF.ofamp_withdelay()
             if setup.ofamp_unconstrained_pulse_constraint[chan_num]!=0:
                 amp_noconstrain_pcon[jj], t0_noconstrain_pcon[jj], chi2_noconstrain_pcon[jj] = OF.ofamp_withdelay(
                                         pulse_direction_constraint=setup.ofamp_unconstrained_pulse_constraint[chan_num])
             
-        if setup.do_ofamp_unconstrained_smooth:
+        if setup.do_ofamp_unconstrained_smooth[chan_num]:
             amp_noconstrain_smooth[jj], t0_noconstrain_smooth[jj], chi2_noconstrain_smooth[jj] = OF_smooth.ofamp_withdelay()
         
-        if setup.ofamp_unconstrained_lowfreqchi2 and setup.do_chi2_lowfreq:
+        if setup.ofamp_unconstrained_lowfreqchi2 and setup.do_chi2_lowfreq[chan_num]:
             chi2low_unconstrain[jj] = OF.chi2_lowfreq(amp_noconstrain[jj], t0_noconstrain[jj], 
                                                       fcutoff=setup.chi2_lowfreq_fcutoff[chan_num])
 
-        if setup.do_ofamp_constrained:
+        if setup.do_ofamp_constrained[chan_num]:
             amp_constrain[jj], t0_constrain[jj], chi2_constrain[jj] = OF.ofamp_withdelay(
                                                                       nconstrain=setup.ofamp_constrained_nconstrain[chan_num])
             if setup.ofamp_constrained_pulse_constraint[chan_num]!=0:
@@ -977,15 +1017,15 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
                                                              nconstrain=setup.ofamp_constrained_nconstrain[chan_num],
                                         pulse_direction_constraint=setup.ofamp_constrained_pulse_constraint[chan_num])
             
-        if setup.do_ofamp_constrained_smooth:
+        if setup.do_ofamp_constrained_smooth[chan_num]:
             amp_constrain_smooth[jj], t0_constrain_smooth[jj], chi2_constrain_smooth[jj] = OF_smooth.ofamp_withdelay(
                                                                       nconstrain=setup.ofamp_constrained_nconstrain[chan_num])
         
-        if setup.ofamp_constrained_lowfreqchi2 and setup.do_chi2_lowfreq:
+        if setup.ofamp_constrained_lowfreqchi2 and setup.do_chi2_lowfreq[chan_num]:
             chi2low_constrain[jj] = OF.chi2_lowfreq(amp_constrain[jj], t0_constrain[jj], 
                                                     fcutoff=setup.chi2_lowfreq_fcutoff[chan_num])
         
-        if setup.do_ofamp_pileup:
+        if setup.do_ofamp_pileup[chan_num]:
             amp_pileup[jj], t0_pileup[jj], chi2_pileup[jj] = OF.ofamp_pileup_iterative(amp_constrain[jj], t0_constrain[jj],
                                                                nconstrain=setup.ofamp_pileup_nconstrain[chan_num])
             if setup.ofamp_pileup_pulse_constraint[chan_num]!=0:
@@ -994,12 +1034,12 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
                                                              nconstrain=setup.ofamp_pileup_nconstrain[chan_num],
                                         pulse_direction_constraint=setup.ofamp_pileup_pulse_constraint[chan_num])
             
-        if setup.do_ofamp_pileup_smooth:
+        if setup.do_ofamp_pileup_smooth[chan_num]:
             amp_pileup_smooth[jj], t0_pileup_smooth[jj], chi2_pileup_smooth[jj] = OF_smooth.ofamp_pileup_iterative(
                                                                amp_constrain_smooth[jj], t0_constrain_smooth[jj],
                                                                nconstrain=setup.ofamp_pileup_nconstrain[chan_num])
         
-        if setup.do_ofamp_baseline:
+        if setup.do_ofamp_baseline[chan_num]:
             amp_baseline[jj], t0_baseline[jj], chi2_baseline[jj] = OF.ofamp_baseline(
                                                                    nconstrain=setup.ofamp_baseline_nconstrain[chan_num])
             if setup.ofamp_baseline_pulse_constraint[chan_num]!=0:
@@ -1007,30 +1047,30 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
                                                              nconstrain=setup.ofamp_baseline_nconstrain[chan_num],
                                         pulse_direction_constraint=setup.ofamp_baseline_pulse_constraint[chan_num])
             
-        if setup.do_ofamp_baseline_smooth:
+        if setup.do_ofamp_baseline_smooth[chan_num]:
             amp_baseline_smooth[jj], t0_baseline_smooth[jj], chi2_baseline_smooth[jj] = OF_smooth.ofamp_baseline(
                                                                    nconstrain=setup.ofamp_baseline_nconstrain[chan_num])
     
     # save variables to dict
-    if setup.do_chi2_nopulse:
+    if setup.do_chi2_nopulse[chan_num]:
         rq_dict[f'chi2_nopulse_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'chi2_nopulse_{chan}{det}'][readout_inds] = chi0
-    if setup.do_chi2_nopulse_smooth:
+    if setup.do_chi2_nopulse_smooth[chan_num]:
         rq_dict[f'chi2_nopulse_smooth_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'chi2_nopulse_smooth_{chan}{det}'][readout_inds] = chi0_smooth
     
-    if setup.do_ofamp_nodelay:
+    if setup.do_ofamp_nodelay[chan_num]:
         rq_dict[f'ofamp_nodelay_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'ofamp_nodelay_{chan}{det}'][readout_inds] = amp_nodelay
         rq_dict[f'chi2_nodelay_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'chi2_nodelay_{chan}{det}'][readout_inds] = chi2_nodelay
-    if setup.do_ofamp_nodelay_smooth:
+    if setup.do_ofamp_nodelay_smooth[chan_num]:
         rq_dict[f'ofamp_nodelay_smooth_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'ofamp_nodelay_smooth_{chan}{det}'][readout_inds] = amp_nodelay_smooth
         rq_dict[f'chi2_nodelay_smooth_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'chi2_nodelay_smooth_{chan}{det}'][readout_inds] = chi2_nodelay_smooth
     
-    if setup.do_ofamp_unconstrained:
+    if setup.do_ofamp_unconstrained[chan_num]:
         rq_dict[f'ofamp_unconstrain_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'ofamp_unconstrain_{chan}{det}'][readout_inds] = amp_noconstrain
         rq_dict[f't0_unconstrain_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
@@ -1044,7 +1084,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
             rq_dict[f't0_unconstrain_pcon_{chan}{det}'][readout_inds] = t0_noconstrain_pcon
             rq_dict[f'chi2_unconstrain_pcon_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
             rq_dict[f'chi2_unconstrain_pcon_{chan}{det}'][readout_inds] = chi2_noconstrain_pcon
-    if setup.do_ofamp_unconstrained_smooth:
+    if setup.do_ofamp_unconstrained_smooth[chan_num]:
         rq_dict[f'ofamp_unconstrain_smooth_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'ofamp_unconstrain_smooth_{chan}{det}'][readout_inds] = amp_noconstrain_smooth
         rq_dict[f't0_unconstrain_smooth_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
@@ -1052,7 +1092,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
         rq_dict[f'chi2_unconstrain_smooth_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'chi2_unconstrain_smooth_{chan}{det}'][readout_inds] = chi2_noconstrain_smooth
     
-    if setup.do_ofamp_constrained:
+    if setup.do_ofamp_constrained[chan_num]:
         rq_dict[f'ofamp_constrain_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'ofamp_constrain_{chan}{det}'][readout_inds] = amp_constrain
         rq_dict[f't0_constrain_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
@@ -1066,7 +1106,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
             rq_dict[f't0_constrain_pcon_{chan}{det}'][readout_inds] = t0_constrain_pcon
             rq_dict[f'chi2_constrain_pcon_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
             rq_dict[f'chi2_constrain_pcon_{chan}{det}'][readout_inds] = chi2_constrain_pcon
-    if setup.do_ofamp_constrained_smooth:
+    if setup.do_ofamp_constrained_smooth[chan_num]:
         rq_dict[f'ofamp_constrain_smooth_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'ofamp_constrain_smooth_{chan}{det}'][readout_inds] = amp_constrain_smooth
         rq_dict[f't0_constrain_smooth_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
@@ -1074,7 +1114,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
         rq_dict[f'chi2_constrain_smooth_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'chi2_constrain_smooth_{chan}{det}'][readout_inds] = chi2_constrain_smooth
         
-    if setup.do_chi2_lowfreq:
+    if setup.do_chi2_lowfreq[chan_num]:
         if setup.ofamp_nodelay_lowfreqchi2:
             rq_dict[f'chi2lowfreq_nodelay_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
             rq_dict[f'chi2lowfreq_nodelay_{chan}{det}'][readout_inds] = chi2low_nodelay
@@ -1087,7 +1127,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
             rq_dict[f'chi2lowfreq_constrain_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
             rq_dict[f'chi2lowfreq_constrain_{chan}{det}'][readout_inds] = chi2low_constrain
     
-    if setup.do_ofamp_pileup:
+    if setup.do_ofamp_pileup[chan_num]:
         rq_dict[f'ofamp_pileup_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'ofamp_pileup_{chan}{det}'][readout_inds] = amp_pileup
         rq_dict[f't0_pileup_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
@@ -1101,7 +1141,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
             rq_dict[f't0_pileup_pcon_{chan}{det}'][readout_inds] = t0_pileup_pcon
             rq_dict[f'chi2_pileup_pcon_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
             rq_dict[f'chi2_pileup_pcon_{chan}{det}'][readout_inds] = chi2_pileup_pcon
-    if setup.do_ofamp_pileup_smooth:
+    if setup.do_ofamp_pileup_smooth[chan_num]:
         rq_dict[f'ofamp_pileup_smooth_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'ofamp_pileup_smooth_{chan}{det}'][readout_inds] = amp_pileup_smooth
         rq_dict[f't0_pileup_smooth_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
@@ -1109,7 +1149,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
         rq_dict[f'chi2_pileup_smooth_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'chi2_pileup_smooth_{chan}{det}'][readout_inds] = chi2_pileup_smooth
         
-    if setup.do_ofamp_baseline:
+    if setup.do_ofamp_baseline[chan_num]:
         rq_dict[f'ofamp_baseline_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'ofamp_baseline_{chan}{det}'][readout_inds] = amp_baseline
         rq_dict[f't0_baseline_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
@@ -1123,7 +1163,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
             rq_dict[f't0_baseline_pcon_{chan}{det}'][readout_inds] = t0_baseline_pcon
             rq_dict[f'chi2_baseline_pcon_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
             rq_dict[f'chi2_baseline_pcon_{chan}{det}'][readout_inds] = chi2_baseline_pcon
-    if setup.do_ofamp_baseline_smooth:
+    if setup.do_ofamp_baseline_smooth[chan_num]:
         rq_dict[f'ofamp_baseline_smooth_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'ofamp_baseline_smooth_{chan}{det}'][readout_inds] = amp_baseline_smooth
         rq_dict[f't0_baseline_smooth_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
@@ -1131,16 +1171,16 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
         rq_dict[f'chi2_baseline_smooth_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'chi2_baseline_smooth_{chan}{det}'][readout_inds] = chi2_baseline_smooth
     
-    if setup.do_ofamp_shifted and setup.trigger is not None:
+    if any(setup.do_ofamp_shifted) and setup.trigger is not None:
         # do the shifted OF on each trace
         if chan_num==setup.trigger:
-            if setup.shifted_fit=="nodelay" and setup.do_ofamp_nodelay:
+            if setup.shifted_fit=="nodelay" and any(setup.do_ofamp_nodelay):
                 setup.t0_shifted = np.zeros(len(signal))
-            elif setup.shifted_fit=="constrained" and setup.do_ofamp_constrained:
+            elif setup.shifted_fit=="constrained" and any(setup.do_ofamp_constrained):
                 setup.t0_shifted = t0_constrain
-            elif setup.shifted_fit=="unconstrained" and setup.do_ofamp_unconstrained:
+            elif setup.shifted_fit=="unconstrained" and any(setup.do_ofamp_unconstrained):
                 setup.t0_shifted = t0_unconstrain
-        else:
+        elif setup.do_ofamp_shifted[chan_num]:
             amp_shifted = np.zeros(len(signal))
             chi2_shifted = np.zeros(len(signal))
 
@@ -1155,17 +1195,17 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
             rq_dict[f'chi2_shifted_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
             rq_dict[f'chi2_shifted_{chan}{det}'][readout_inds] = chi2_shifted
             
-    if setup.do_ofamp_shifted_smooth and setup.trigger is not None:
+    if any(setup.do_ofamp_shifted_smooth) and setup.trigger is not None:
         # do the shifted OF on each trace
         if chan_num==setup.trigger:
             if not setup.do_ofamp_shifted:
-                if setup.shifted_fit=="nodelay" and setup.do_ofamp_nodelay_smooth:
+                if setup.shifted_fit=="nodelay" and any(setup.do_ofamp_nodelay_smooth):
                     setup.t0_shifted = np.zeros(len(signal))
-                elif setup.shifted_fit=="constrained" and setup.do_ofamp_constrained_smooth:
+                elif setup.shifted_fit=="constrained" and any(setup.do_ofamp_constrained_smooth):
                     setup.t0_shifted = t0_constrain
-                elif setup.shifted_fit=="unconstrained" and setup.do_ofamp_unconstrained_smooth:
+                elif setup.shifted_fit=="unconstrained" and any(setup.do_ofamp_unconstrained_smooth):
                     setup.t0_shifted = t0_unconstrain
-        else:
+        elif setup.do_ofamp_shifted_smooth[chan_num]:
             amp_shifted_smooth = np.zeros(len(signal))
             chi2_shifted_smooth = np.zeros(len(signal))
 

--- a/rqpy/process/_process_rq.py
+++ b/rqpy/process/_process_rq.py
@@ -225,7 +225,7 @@ class SetupRQ(object):
         
         if self.indstop - self.indstart != len(self.templates[0]):
             raise ValueError("The indices specified indstart and indstop will result in each"+\
-                             "truncated trace having a different length than their corresponding"+\ 
+                             "truncated trace having a different length than their corresponding"+\
                              "psd and template. Make sure indstart-indstop = the length of the"+\
                              "template/psd")
         
@@ -345,8 +345,8 @@ class SetupRQ(object):
         
         Returns
         -------
-        kwargs.values() : dict_values
-            A dict_values object that contains the list of values for each inputted kwarg, in the
+        out : list
+            The list of values for each inputted kwarg, in the
             order that they were inputted.
             
         Raises
@@ -369,8 +369,13 @@ class SetupRQ(object):
 
             if len(kwargs[key])!=self.nchan:
                 raise ValueError(f"The length of {key} is not equal to the number of channels")
-
-        return kwargs.values()
+        
+        out = list(kwargs.values())
+        
+        if len(out)==1:
+            out = out[0]
+        
+        return out
 
     def adjust_calc(self, lgcchans=True, lgcsum=True):
         """


### PR DESCRIPTION
The changes in this pull request include:

1. Updates to the `SetupRQ` docstring
2. In the adjust methods, `lgcrun` and `lgcrun_smooth` can now be inputted as lists of bool in order to calculate RQs only for specific channels.
3. Added the ability for truncating the traces when calculating RQs, as requested in Issue #37.
4. Added method (`SetupRQ._check_of()`) check for if any OFs will be calculated, to avoid initializing the `qetpy.OptimumFilter` class unnecessarily.
5. Added `SetupRQ._check_arg_length()` for checking if parameters are scalar and if they are the correct length.
6. Added support for constrained pulse direction, as requested in Issue #34.
7. Changed some default parameters in `SetupRQ` to be trace length agnostic.

I created the `enhancement/energy_absorbed_rq` branch off of this branch in response to Issue #36, which includes the Energy Absorbed RQ. However, that has a dependency on a current issue in QETpy (https://github.com/ucbpylegroup/QETpy/issues/29), so a PR for that RQ will be created at a different time.