### PR TITLE
Updates to rqpy.passageplot and rqpy.passage_fraction

### DIFF
--- a/rqpy/core/_cut.py
+++ b/rqpy/core/_cut.py
@@ -325,8 +325,7 @@ def passage_fraction(x, cut, basecut=None, nbins=100, lgcequaldensitybins=False)
     Returns
     -------
     x_binned : ndarray
-        The corresponding `x` values for each passage fraction, corresponding to the
-        center of the bin.
+        The corresponding `x` values for each passage fraction, given as the edges of each bin.
     frac_binned : ndarray
         The passage fractions for each value of `x_binned` for the given `cut` and `basecut`.
     
@@ -344,7 +343,8 @@ def passage_fraction(x, cut, basecut=None, nbins=100, lgcequaldensitybins=False)
     hist_vals_base, x_binned = np.histogram(x[basecut], bins=nbins)
     hist_vals, _ = np.histogram(x[basecut & cut], bins=x_binned)
     
+    hist_vals_base[hist_vals_base==0] = 1
+    
     frac_binned = hist_vals/hist_vals_base
-    x_binned = (x_binned[:-1]+x_binned[1:])/2
     
     return x_binned, frac_binned

--- a/rqpy/plotting/_plotting.py
+++ b/rqpy/plotting/_plotting.py
@@ -394,10 +394,20 @@ def passageplot(arr, cuts, basecut=None, nbins=100, lgcequaldensitybins=False, x
 
     ctemp = np.ones(len(arr), dtype=bool) & basecut
     
+    if xlims is None:
+        xlimitcut = np.ones(len(arr), dtype=bool)
+    else:
+        xlimitcut = rp.inrange(arr, xlims[0], xlims[1])
+    
     for ii, cut in enumerate(cuts):
         oldsum = ctemp.sum()
-        x_binned, passage_binned = rp.passage_fraction(arr, cut, basecut=ctemp, nbins=nbins,
-                                                       lgcequaldensitybins=lgcequaldensitybins)
+        
+        if ii==0:
+            x_binned, passage_binned = rp.passage_fraction(arr, cut, basecut=ctemp & xlimitcut, nbins=nbins,
+                                                           lgcequaldensitybins=lgcequaldensitybins)
+        else:
+            x_binned, passage_binned = rp.passage_fraction(arr, cut, basecut=ctemp & xlimitcut, nbins=x_binned)
+        
         ctemp = ctemp & cut
         newsum = ctemp.sum()
         cuteff = newsum/oldsum * 100
@@ -408,8 +418,11 @@ def passageplot(arr, cuts, basecut=None, nbins=100, lgcequaldensitybins=False, x
             
         if xlims is None:
             xlims = (x_binned.min()*0.9, x_binned.max()*1.1)
-            
-        ax.step(x_binned, passage_binned, where='mid', color=colors[ii], label=label)
+        
+        bin_centers = (x_binned[1:]+x_binned[:-1])/2
+        
+        ax.hist(bin_centers, bins=x_binned, weights=passage_binned, histtype='step', 
+                color=colors[ii], label=label, linewidth=2)
     
     ax.set_xlim(xlims)
     ax.set_ylim(ylims)


### PR DESCRIPTION
Some changes to `rqpy.passageplot` and `rqpy.passage_fraction`.

1. `rqpy.passage_fraction` outputs bin edges instead of bin centers, no longer will divide by zero
2. `rqpy.passageplot` makes better looking histograms and the bin sizes are now the same for successive cuts



