### PR TITLE
Changed rqpy.binnedcut output

### DIFF
--- a/rqpy/core/_cut.py
+++ b/rqpy/core/_cut.py
@@ -325,8 +325,7 @@ def passage_fraction(x, cut, basecut=None, nbins=100, lgcequaldensitybins=False)
     Returns
     -------
     x_binned : ndarray
-        The corresponding `x` values for each passage fraction, corresponding to the
-        center of the bin.
+        The corresponding `x` values for each passage fraction, given as the edges of each bin.
     frac_binned : ndarray
         The passage fractions for each value of `x_binned` for the given `cut` and `basecut`.
     
@@ -344,7 +343,8 @@ def passage_fraction(x, cut, basecut=None, nbins=100, lgcequaldensitybins=False)
     hist_vals_base, x_binned = np.histogram(x[basecut], bins=nbins)
     hist_vals, _ = np.histogram(x[basecut & cut], bins=x_binned)
     
+    hist_vals_base[hist_vals_base==0] = 1
+    
     frac_binned = hist_vals/hist_vals_base
-    x_binned = (x_binned[:-1]+x_binned[1:])/2
     
     return x_binned, frac_binned

--- a/rqpy/core/_cut.py
+++ b/rqpy/core/_cut.py
@@ -128,7 +128,7 @@ class GenericModel(object):
 
 def binnedcut(x, y, cut=None, nbins=100, cut_eff=0.9, keep_large_vals=True, lgcequaldensitybins=False,
               xlwrlim=None, xuprlim=None, model=None, guess=None, residual_threshold=2, min_samples=None, 
-              lgcrtnparams=False, **kwargs):
+              **kwargs):
     """
     Function for calculating a cut given a desired passage fraction, based on binning the data.
     
@@ -180,9 +180,6 @@ def binnedcut(x, y, cut=None, nbins=100, cut_eff=0.9, keep_large_vals=True, lgce
         `skimage.measure.ransac` function, of which this is a parameter. If left as None, then this
         is set to the length of the guess for user-defined functions or set to two for the linear 
         model.
-    lgcrtnparams : bool, optional
-        Boolean flag for returning the fit parameters, in the case of a user-defined function being
-        passed to `model`.
     kwargs
         Keyword arguments passed to `skimage.measure.ransac`. See [1].
         
@@ -190,9 +187,10 @@ def binnedcut(x, y, cut=None, nbins=100, cut_eff=0.9, keep_large_vals=True, lgce
     -------
     cbinned : array_like
         A boolean mask indicating which data points passed the baseline cut.
-    params : ndarray, optional
-        If `lgcrtnparams` is True, and a user-defined function was passed to `model`, the fit parameters
-        are also returned.
+    cutobj : object
+        An object that contains the parameters of the fitted model (if `model` is not None, otherwise 
+        this is None) and the function that generates the cut boundary, where the two attributes are
+        `params` and `f_boundary`, respectively.
         
     Notes
     -----
@@ -237,6 +235,7 @@ def binnedcut(x, y, cut=None, nbins=100, cut_eff=0.9, keep_large_vals=True, lgce
             f = interpolate.interp1d(bin_edges[1:-1], cutoffs[1:], kind='previous', 
                                      bounds_error=False, fill_value=(cutoffs[0], cutoffs[-1]),
                                      assume_sorted=True)
+            params = None
         else: 
             if model=="linear":
                 ModelClass = measure.LineModelND
@@ -261,20 +260,23 @@ def binnedcut(x, y, cut=None, nbins=100, cut_eff=0.9, keep_large_vals=True, lgce
                 model_robust, _ = measure.ransac(np.stack((bin_edges[1:-1], cutoffs[1:]), axis=1),
                                                  ModelClass, min_samples, residual_threshold, 
                                                  **kwargs)
+            params = model_robust.params
             if model=="linear":
-                f = lambda var: ModelClass().predict_y(var, model_robust.params)
+                f = lambda var: ModelClass().predict_y(var, params)
             else:
-                f = lambda var: model(var, *model_robust.params)
+                f = lambda var: model(var, *params)
                 
     if keep_large_vals:
-        cbinned = (y > f(x)) & cut
+        f_cut = lambda var: (y > f(var)) & cut
     else:
-        cbinned = (y < f(x)) & cut
+        f_cut = lambda var: (y < f(var)) & cut
     
-    if lgcrtnparams and model is not None and model!="linear":
-        return cbinned, model_robust.params
-    else:
-        return cbinned
+    cbinned = f_cut(x)
+    
+    cutobj = type('cutobj', (object,), {'params'     : params,
+                                        'f_boundary' : f})
+    
+    return cbinned, cutobj
 
 def inrange(vals, lwrbnd, uprbnd):
     """

--- a/rqpy/plotting/_plotting.py
+++ b/rqpy/plotting/_plotting.py
@@ -394,10 +394,20 @@ def passageplot(arr, cuts, basecut=None, nbins=100, lgcequaldensitybins=False, x
 
     ctemp = np.ones(len(arr), dtype=bool) & basecut
     
+    if xlims is None:
+        xlimitcut = np.ones(len(arr), dtype=bool)
+    else:
+        xlimitcut = rp.inrange(arr, xlims[0], xlims[1])
+    
     for ii, cut in enumerate(cuts):
         oldsum = ctemp.sum()
-        x_binned, passage_binned = rp.passage_fraction(arr, cut, basecut=ctemp, nbins=nbins,
-                                                       lgcequaldensitybins=lgcequaldensitybins)
+        
+        if ii==0:
+            x_binned, passage_binned = rp.passage_fraction(arr, cut, basecut=ctemp & xlimitcut, nbins=nbins,
+                                                           lgcequaldensitybins=lgcequaldensitybins)
+        else:
+            x_binned, passage_binned = rp.passage_fraction(arr, cut, basecut=ctemp & xlimitcut, nbins=x_binned)
+        
         ctemp = ctemp & cut
         newsum = ctemp.sum()
         cuteff = newsum/oldsum * 100
@@ -408,8 +418,11 @@ def passageplot(arr, cuts, basecut=None, nbins=100, lgcequaldensitybins=False, x
             
         if xlims is None:
             xlims = (x_binned.min()*0.9, x_binned.max()*1.1)
-            
-        ax.step(x_binned, passage_binned, where='mid', color=colors[ii], label=label)
+        
+        bin_centers = (x_binned[1:]+x_binned[:-1])/2
+        
+        ax.hist(bin_centers, bins=x_binned, weights=passage_binned, histtype='step', 
+                color=colors[ii], label=label, linewidth=2)
     
     ax.set_xlim(xlims)
     ax.set_ylim(ylims)


### PR DESCRIPTION
`rqpy.binnedcut` now always outputs the cut and an object that contains the fitted parameters and the function that the cut boundary was specified by.