### PR TITLE
Replaced ds_trunc with improved function downsample_truncate

### DIFF
--- a/rqpy/core/_pulse.py
+++ b/rqpy/core/_pulse.py
@@ -1,6 +1,6 @@
 import numpy as np
 import qetpy as qp
-from scipy.signal import decimate
+from scipy import signal
 
 
 __all__ = ["shift", "make_ideal_template", "downsample_truncate"]


### PR DESCRIPTION
I replaced the function `rqpy.ds_trunc` with an improved function, which was renamed to `rqpy.downsample_truncate`. The function now has optional arguments for calculating downsampled PSDs or templates, whereas it was not optional before.