### PR TITLE
Fixed bugs in Pulse Sim

### DIFF
--- a/rqpy/io/_load.py
+++ b/rqpy/io/_load.py
@@ -131,7 +131,7 @@ def getrandevents(basepath, evtnums, seriesnums, cut=None, channels=["PDS1"], de
             arr = getRawEvents(f"{basepath}{snum_str}/", "", channelList=channels, detectorList=list(set(dets)),
                                outputFormat=3, eventNumbers=evtnums[cseries].astype(int).tolist())
         elif filetype == "npz":
-            dumpnums = np.asarray(rq.eventnumber/10000, dtype=int)
+            dumpnums = np.asarray(evtnums/10000, dtype=int)
             
             snum_str = f"{snum:010}"
             snum_str = snum_str[:6] + '_' + snum_str[6:]

--- a/rqpy/sim/_pulse_sim.py
+++ b/rqpy/sim/_pulse_sim.py
@@ -109,7 +109,7 @@ def buildfakepulses(rq, cut, template1, amplitudes1, tdelay1, basepath,
 
     last_dump_ind = -(ntraces%neventsperdump) if ntraces%neventsperdump else None
 
-    nonzerocutinds = np.flatnonzero(ctest)
+    nonzerocutinds = np.flatnonzero(cut)
 
     split_cut = np.split(nonzerocutinds[:last_dump_ind], ntraces//neventsperdump)
     split_amplitudes1 = np.split(amplitudes1[:last_dump_ind], ntraces//neventsperdump)

--- a/rqpy/sim/_pulse_sim.py
+++ b/rqpy/sim/_pulse_sim.py
@@ -15,10 +15,11 @@ if HAS_SCDMSPYTOOLS:
 __all__ = ["buildfakepulses"]
 
 
-def buildfakepulses(rq, cut, template1, amplitudes1, tdelay1, basepath, evtnums, seriesnums,
-                    template2=None, amplitudes2=None, tdelay2=None, channels="PDS1",
-                    det="Z1", relcal=None, convtoamps=1, fs=625e3, neventsperdump=1000,
-                    filetype="mid.gz", lgcsavefile=False, savefilepath=None, savefilename=None):
+def buildfakepulses(rq, cut, template1, amplitudes1, tdelay1, basepath,
+                    template2=None, amplitudes2=None, tdelay2=None,
+                    channels="PDS1", det="Z1", relcal=None, convtoamps=1,
+                    fs=625e3, neventsperdump=1000, filetype="mid.gz",
+                    lgcsavefile=False, savefilepath=None, savefilename=None):
     """
     Function for building fake pulses by adding a template, scaled to certain amplitudes and
     certain time delays, to an existing trace (typically a random).
@@ -43,10 +44,6 @@ def buildfakepulses(rq, cut, template1, amplitudes1, tdelay1, basepath, evtnums,
     basepath : str
         The base path to the directory that contains the folders that the event dumps 
         are in. The folders in this directory should be the series numbers.
-    evtnums : array_like
-        An array of all event numbers for the events in all datasets.
-    seriesnums : array_like
-        An array of the corresponding series numbers for each event number in evtnums.
     template2 : ndarray, optional
         The 2nd template to be added to the traces, otherwise same as `template1`.
     amplitudes2 : ndarray, optional
@@ -136,17 +133,18 @@ def buildfakepulses(rq, cut, template1, amplitudes1, tdelay1, basepath, evtnums,
         cut_seg[c] = True
         
         _buildfakepulses_seg(rq, cut_seg, template1, split_amplitudes1[ii], split_tdelay1[ii], 
-                             basepath, evtnums, seriesnums, template2=template2, 
-                             amplitudes2=split_amplitudes2[ii], tdelay2=split_tdelay2[ii], 
-                             channels=channels, relcal=relcal, det=det, convtoamps=convtoamps, 
-                             fs=fs, dumpnum=ii+1, filetype=filetype, lgcsavefile=lgcsavefile, 
+                             basepath, template2=template2, amplitudes2=split_amplitudes2[ii],
+                             tdelay2=split_tdelay2[ii], channels=channels, relcal=relcal,
+                             det=det, convtoamps=convtoamps, fs=fs, dumpnum=ii+1,
+                             filetype=filetype, lgcsavefile=lgcsavefile,
                              savefilepath=savefilepath, savefilename=savefilename)
     
     
-def _buildfakepulses_seg(rq, cut, template1, amplitudes1, tdelay1, basepath, evtnums, seriesnums,
-                         template2=None, amplitudes2=None, tdelay2=None, channels="PDS1", relcal=None,
-                         det="Z1", convtoamps=1, fs=625e3, dumpnum=1, filetype="mid.gz",
-                         lgcsavefile=False, savefilepath=None, savefilename=None):
+def _buildfakepulses_seg(rq, cut, template1, amplitudes1, tdelay1, basepath,
+                         template2=None, amplitudes2=None, tdelay2=None,
+                         channels="PDS1", relcal=None, det="Z1", convtoamps=1,
+                         fs=625e3, dumpnum=1, filetype="mid.gz", lgcsavefile=False,
+                         savefilepath=None, savefilename=None):
     """
     Hidden helper function for building fake pulses.
               
@@ -168,10 +166,6 @@ def _buildfakepulses_seg(rq, cut, template1, amplitudes1, tdelay1, basepath, evt
     basepath : str
         The base path to the directory that contains the folders that the event dumps 
         are in. The folders in this directory should be the series numbers.
-    evtnums : array_like
-        An array of all event numbers for the events in all datasets.
-    seriesnums : array_like
-        An array of the corresponding series numbers for each event number in evtnums.
     template2 : ndarray, optional
         The 2nd template to be added to the traces, otherwise same as `template1`.
     amplitudes2 : ndarray, optional

--- a/rqpy/sim/_pulse_sim.py
+++ b/rqpy/sim/_pulse_sim.py
@@ -110,16 +110,25 @@ def buildfakepulses(rq, cut, template1, amplitudes1, tdelay1, basepath,
     last_dump_ind = -(ntraces%neventsperdump) if ntraces%neventsperdump else None
 
     nonzerocutinds = np.flatnonzero(cut)
-
-    split_cut = np.split(nonzerocutinds[:last_dump_ind], ntraces//neventsperdump)
-    split_amplitudes1 = np.split(amplitudes1[:last_dump_ind], ntraces//neventsperdump)
-    split_tdelay1 = np.split(tdelay1[:last_dump_ind], ntraces//neventsperdump)
+    
+    split_cut = []
+    split_amplitudes1 = []
+    split_tdelay1 = []
     
     if template2 is not None:
-        split_amplitudes2 = np.split(amplitudes2[:last_dump_ind], ntraces//neventsperdump)
-        split_tdelay2 = np.split(tdelay2[:last_dump_ind], ntraces//neventsperdump)
+        split_amplitudes2 = []
+        split_tdelay2 = []
 
-    if last_dump is not None:
+    if ntraces//neventsperdump > 0:
+        split_cut.extend(np.split(nonzerocutinds[:last_dump_ind], ntraces//neventsperdump))
+        split_amplitudes1.extend(np.split(amplitudes1[:last_dump_ind], ntraces//neventsperdump))
+        split_tdelay1.extend(np.split(tdelay1[:last_dump_ind], ntraces//neventsperdump))
+
+        if template2 is not None:
+            split_amplitudes2.extend(np.split(amplitudes2[:last_dump_ind], ntraces//neventsperdump))
+            split_tdelay2.extend(np.split(tdelay2[:last_dump_ind], ntraces//neventsperdump))
+
+    if last_dump_ind is not None:
         split_cut.append(nonzerocutinds[last_dump_ind:])
         split_amplitudes1.append(amplitudes1[last_dump_ind:])
         split_tdelay1.append(tdelay1[last_dump_ind:])
@@ -132,9 +141,16 @@ def buildfakepulses(rq, cut, template1, amplitudes1, tdelay1, basepath,
         cut_seg = np.zeros(cutlen, dtype=bool)
         cut_seg[c] = True
         
+        if template2 is None:
+            split_amplitudes2_seg = None
+            split_tdelay2_seg = None
+        else:
+            split_amplitudes2_seg = split_amplitudes2[ii]
+            split_tdelay2_seg = split_tdelay2[ii]
+        
         _buildfakepulses_seg(rq, cut_seg, template1, split_amplitudes1[ii], split_tdelay1[ii], 
-                             basepath, template2=template2, amplitudes2=split_amplitudes2[ii],
-                             tdelay2=split_tdelay2[ii], channels=channels, relcal=relcal,
+                             basepath, template2=template2, amplitudes2=split_amplitudes2_seg,
+                             tdelay2=split_tdelay2_seg, channels=channels, relcal=relcal,
                              det=det, convtoamps=convtoamps, fs=fs, dumpnum=ii+1,
                              filetype=filetype, lgcsavefile=lgcsavefile,
                              savefilepath=savefilepath, savefilename=savefilename)


### PR DESCRIPTION
Fixed some bugs in the pulse sim, as well as refactored a little bit.

Some changes:
- the cut is now correctly applied to the simulated data
- removed unnecessary `evtnums` and `seriesnums` parameters
- fixed file opening in `getrandevents` for `npz` files.