### PR TITLE
Add the Trigger Simulation for mid.gz files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,35 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.1.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-docstring-first
+    -   id: check-yaml
+    -   id: debug-statements
+    -   id: requirements-txt-fixer
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.1
+    hooks:
+    -   id: flake8
+-   repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: v1.4.3
+    hooks:
+    -   id: autopep8
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v1.11.1
+    hooks:
+    -   id: pyupgrade
+-   repo: https://github.com/asottile/reorder_python_imports
+    rev: v1.3.5
+    hooks:
+    -   id: reorder-python-imports
+        language_version: python3
+-   repo: https://github.com/asottile/add-trailing-comma
+    rev: v0.7.1
+    hooks:
+    -   id: add-trailing-comma
+-   repo: meta
+    hooks:
+    -   id: check-hooks-apply
+    -   id: check-useless-excludes

--- a/rqpy/__init__.py
+++ b/rqpy/__init__.py
@@ -1,4 +1,4 @@
-from ._globals import HAS_SCDMSPYTOOLS
+from ._globals import HAS_SCDMSPYTOOLS, HAS_TRIGSIM
 from . import core
 from .core import *
 from . import plotting

--- a/rqpy/_globals.py
+++ b/rqpy/_globals.py
@@ -2,13 +2,20 @@ from importlib.util import find_spec
 import sys
 
 package_req = 'scdmsPyTools'
-
 spec = find_spec(package_req)
 
 if spec is None:
     HAS_SCDMSPYTOOLS = False
 else:
     HAS_SCDMSPYTOOLS = True
+
+package_req = 'trigsim'
+spec = find_spec(package_req)
+
+if spec is None:
+    HAS_TRIGSIM = False
+else:
+    HAS_TRIGSIM = True
 
 del find_spec
 del sys

--- a/rqpy/process/_process_rq.py
+++ b/rqpy/process/_process_rq.py
@@ -1183,7 +1183,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
         chi2_nonlin = np.zeros(len(signal))
     
     if setup.do_trigsim[chan_num] and setup.trigger == chan_num:
-        triggeramp_sim = np.zero(len(signal))
+        triggeramp_sim = np.zeros(len(signal))
     
     # run the OF class for each trace
     if setup.do_optimumfilters[chan_num]:

--- a/rqpy/sim/__init__.py
+++ b/rqpy/sim/__init__.py
@@ -1,1 +1,2 @@
 from ._pulse_sim import *
+from ._trig_sim import *

--- a/rqpy/sim/_trig_sim.py
+++ b/rqpy/sim/_trig_sim.py
@@ -181,7 +181,7 @@ class TrigSim(object):
         """
         
         if not self.lgc_can_run_trigger:
-            raise ValueError("The threshold was not set, please use the TrigSim.set_threhold method.")
+            raise ValueError("The threshold was not set, please use the TrigSim.set_threshold method.")
         
         input_traces = [(x[k:] - 32768).astype('int64')] + [np.zeros(len(x[k:]),dtype='int64')]*11 + \
                        [np.zeros(4*len(x[k:]),dtype='int64')]*4

--- a/rqpy/sim/_trig_sim.py
+++ b/rqpy/sim/_trig_sim.py
@@ -1,0 +1,123 @@
+from scipy import signal
+import qetpy as qp
+import rqpy as rp
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+from glob import glob
+import pickle as pkl
+from rqpy import HAS_TRIGSIM
+
+if HAS_TRIGSIM:
+    import trigsim
+
+
+__all__ = ["TrigSim"]
+
+
+class TrigSim(object):
+    """
+    Class for setting up the DCRC FIR filter trigger simulation.
+    
+    Attributes
+    ----------
+    trig : Object
+        The `trigsim.Trigger` object which is used to build and run the FIR filter.
+    resolution : ndarray
+        The resolution of the FIR filter in the arbitrary units of the filter.
+    
+    """
+    
+    def __init__(self, psd, template, fs, nsigma=5):
+        """
+        Initialization of the TrigSim class.
+        
+        Parameters
+        ----------
+        psd : ndarray
+            The input power spectral density to use for the FIR filter. Should be in
+            units of ADC bins.
+        template : ndarray
+            The pulse template to use for the FIR filter. Should be normalized to have a
+            height of 1.
+        fs : float
+            The digitization rate of the data in Hz.
+        nsigma : float, optional
+            The number of standard deviations of the energy resolution to use as the threshold 
+            for which events will be detected as a pulse in the FIR filter.
+        
+        """
+        
+        if not HAS_TRIGSIM:
+            raise ImportError("Cannot run the trigger simulation because trigsim is not installed.")
+        
+        input_PSDs = [psd]*12 + [np.ones(4*len(psd))]*4
+        input_pulse_shapes = [template]*12 + [np.zeros(4*template.shape[0])]*4
+
+        raw_LC_coeffs = np.zeros((4,16))
+        which_channel = 0
+        raw_LC_coeffs[0, which_channel] = 1 # only one phonon channel
+        LC_coeffs = trigsim.scale_max(raw_LC_coeffs, bits=8, axis=1)
+        TrL_requires = np.zeros((8,16), dtype=bool)
+        TrL_vetos = np.zeros((8,16), dtype=bool)
+
+        self.trig = trigsim.Trigger(bits_phonon=16, bits_charge=16,
+                                    phonon_DF_R=16, phonon_DF_N=3, phonon_DF_M=1, phonon_start=0,
+                                    charge_DF_R=64, charge_DF_N=3, charge_DF_M=1, charge_start=0,
+                                    LC_coeffs=LC_coeffs, LC_bits_out=46,
+                                    LC_bits_coeff=8, LC_discard_MSBs=[0,0,0,0],
+                                    FIR_coeffs=np.zeros((4,1024), 'i8'), FIR_bits_out=32, 
+                                    FIR_bits_coeff=16, FIR_discard_MSBs=[4,0,0,0],
+                                    ThL_selectors=np.array([0,1,2,3,1,1,2,3], dtype='uint'),
+                                    ThL_activation_thresholds   = (2**15 - 1)*np.ones(8, int),
+                                    ThL_deactivation_thresholds = np.zeros(8, int),
+                                    PS_max_window_lengths=(2**31 - 1)*np.ones(4, dtype='uint'),
+                                    PS_saturated_pulse_offsets=np.zeros(4, dtype='uint'),
+                                    TrL_selectors=np.array([0,1,2,3,1,1,2,3], dtype='uint'),
+                                    TrL_enables=np.array([1,0,0,0,0,0,0,0], dtype=bool),
+                                    TrL_requires=TrL_requires, TrL_vetos=TrL_vetos,
+                                    TrL_prescales=np.ones(8, dtype='float'))
+        
+        OF_coeffs = self.trig.build_OF_coeffs(input_PSDs, input_pulse_shapes)
+        self.trig.set_FIR_coeffs(OF_coeffs)
+        self.resolution = self.trig.resolution(input_PSDs, deltaT_phonon=1/fs)
+        self.trig.ThL.ThLs[which_channel].set_thresholds(np.int64(nsigma*self.resolution), 0)
+        
+    def trigger(self, x, k=12):
+        """
+        Method for sending a trace to run the trigger simulation on.
+        
+        Parameters
+        ----------
+        x : ndarray
+            The input array to run the FIR filter on. Should be a 1-d ndarray in units of 
+            ADC bins.
+        k : int, optional
+            The bin number to start the FIR filter at. Since the filter downsamples the data
+            by a factor of 16, the starting bin has a small effect on the calculated amplitude.
+        
+        Returns
+        -------
+        triggeramp : int
+            The trigger amplitude of the pulse as calculated by the FIR filter, in the arbitrary 
+            units of the filter. Taken from the maximum amplitude in the trace.
+        fir_out : ndarray
+            The complete, filtered trace corresponding to the inputted trace, in the arbitrary
+            units of the filter.
+        
+        """
+        
+        input_traces = [(x[k:] - 32768).astype('int64')] + [np.zeros(len(x[k:]),dtype='int64')]*11 + \
+                       [np.zeros(4*len(x[k:]),dtype='int64')]*4
+        
+        self.trig.reset()
+        
+        pipe = trigsim.pipeline(self.trig.DF, self.trig.LC, self.trig.LC_trunc, 
+                                 self.trig.FIR, self.trig.FIR_trunc)
+        
+        fir_out = pipe.send(input_traces)
+        
+        triggeramp = fir_out[0, 1024:].max()
+        
+        return triggeramp, fir_out
+


### PR DESCRIPTION
The branch `feature/trigsim` is in a good state to merge to master.

- Added `rqpy.sim.TrigSim`, which is a wrapper around the `trigsim` package developed by Jon Wilson
- Added the trigger simulation amplitude to the RQ processing
- Added a pre-commit yaml file for fun
- Checks for having the `trigsim` package installed

Should be good to go! May make small changes somewhere down the line, but it does its job.

In response to Issue #61.