### PR TITLE
Update RQ processing to make compatible with latest QETpy commits

### DIFF
--- a/rqpy/process/_process_rq.py
+++ b/rqpy/process/_process_rq.py
@@ -1281,7 +1281,11 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
             else:
                 flip = -1
             
-            params_nlin, errors_nlin, _, reducedchi2_nlin = nlin.fit_falltimes(flip*s, npolefit=2, lgcfullrtn=True)
+            res_nlin = nlin.fit_falltimes(flip*s, npolefit=2, lgcfullrtn=True)
+            
+            params_nlin = res_nlin[0]
+            errors_nlin = res_nlin[1]
+            reducedchi2_nlin = res_nlin[3]
             
             amp_nonlin[jj] = flip*params_nlin[0]
             amp_nonlin_err[jj] = errors_nlin[0]


### PR DESCRIPTION
In PR https://github.com/ucbpylegroup/QETpy/pull/48, `qetpy.OFnonlin.fit_falltimes` returns a different number of arguments. I've changed the processing so that it is compatible with either version of QETpy.

This is in response to Issue #67, but does not deal with Issue #58. 