### PR TITLE
Allow a list of paths to be passed to process_ivsweep

### DIFF
--- a/rqpy/process/_process_iv_didv.py
+++ b/rqpy/process/_process_iv_didv.py
@@ -226,8 +226,9 @@ def process_ivsweep(ivfilepath, chans, detectorid="Z1", rfb=5000, loopgain=2.4, 
     
     Parameters
     ----------
-    ivfilepath : str
-        Absolute path to the directory containing all the series in the sweep
+    ivfilepath : str, list of str
+        Absolute path to the directory containing all the series in the sweep. Can also pass a list of specific
+        paths to the parent directories of files to process.
     chans : list
         List containing strings corresponding to the names of all the channels of interest
     detectorid : str, optional
@@ -295,7 +296,10 @@ def process_ivsweep(ivfilepath, chans, detectorid="Z1", rfb=5000, loopgain=2.4, 
         raise ImportError("""Cannot use this IV processing because scdmsPyTools is not installed. 
                           More file types will be supported in future releases of RQpy.""")
     
-    files = sorted(glob(ivfilepath +'*/'))
+    if isinstance(files, str):
+        files = sorted(glob(ivfilepath +'*/'))
+    else:
+        files = ivfilepath
     
     if nprocess == 1:
         results = []

--- a/rqpy/process/_process_iv_didv.py
+++ b/rqpy/process/_process_iv_didv.py
@@ -296,7 +296,7 @@ def process_ivsweep(ivfilepath, chans, detectorid="Z1", rfb=5000, loopgain=2.4, 
         raise ImportError("""Cannot use this IV processing because scdmsPyTools is not installed. 
                           More file types will be supported in future releases of RQpy.""")
     
-    if isinstance(files, str):
+    if isinstance(ivfilepath, str):
         files = sorted(glob(ivfilepath +'*/'))
     else:
         files = ivfilepath


### PR DESCRIPTION
I've added a small change so that a list of paths to the parent directories of the files to process can be passed to `rqpy.process.process_ivsweep`. This is useful, for example, when running the code on a cluster to process files in parallel.