### PR TITLE
Switch the order of the priors and non-priors dIdV fits in IVanalysis

### DIFF
--- a/rqpy/core/_iv_didv_tools.py
+++ b/rqpy/core/_iv_didv_tools.py
@@ -631,8 +631,8 @@ class IVanalysis(object):
                                        rload=self.rload, rload_err = self.rshunt_err, r0=r0, r0_err=dr0,
                                        priors = priors, invpriorscov = invpriorsCov)
 
-            didvobj.dopriorsfit()
             didvobj.dofit(poles=2)
+            didvobj.dopriorsfit()
             
             self.df.iat[int(np.flatnonzero(self.didvinds)[ind]), self.df.columns.get_loc('didvobj')] = didvobj
             self.df.iat[int(np.flatnonzero(self.noiseinds)[ind]), self.df.columns.get_loc('didvobj')] = didvobj


### PR DESCRIPTION
I've switched the order of the priors fit and the non-priors fit in the `rqpy.IVanalysis`. This was done to have the priors fit use the non-priors fit's values as the guesses. The reason being that the non-priors fit tends to have a better fit to the time shift value, so the non-priors fit should use the same time shift value as the guess. This helps make sure the priors and non-priors fits will converge, which they should in the case of only passing R_0 and R_\ell.