### PR TITLE
Adding Passage Fraction Error Information

### DIFF
--- a/rqpy/core/_cut.py
+++ b/rqpy/core/_cut.py
@@ -308,7 +308,7 @@ def passage_fraction(x, cut, basecut=None, nbins=100, lgcequaldensitybins=False)
     """
     Function for returning the passage fraction of a cut as a function of the specified
     variable `x`.
-    
+
     Parameters
     ----------
     x : array_like
@@ -323,30 +323,60 @@ def passage_fraction(x, cut, basecut=None, nbins=100, lgcequaldensitybins=False)
     lgcequaldensitybins : bool, optional
         If set to True, the bin widths are set such that each bin has the same number
         of data points within it. If left as False, then a constant bin width is used.
-    
+
     Returns
     -------
     x_binned : ndarray
         The corresponding `x` values for each passage fraction, given as the edges of each bin.
-    frac_binned : ndarray
-        The passage fractions for each value of `x_binned` for the given `cut` and `basecut`.
-    
+    frac_binned_mp : ndarray
+        The most probable (measured) passage fraction for each value of `x_binned` for the given
+        `cut` and `basecut`.
+    frac_binned_biased : ndarray
+        The expected value of the passage fraction for each value of `x_binned` for the given
+        `cut` and `basecut`. See Notes for more information.
+    frac_binned_err : ndarray
+        The standard deviation of the passage fraction for each value of `x_binned` for the
+        given `cut` and `basecut`, where this is centered on the values of `frac_binned_biased`.
+        See Notes for more information.
+
+    Notes
+    -----
+    The errors are based on the derivation in https://arxiv.org/pdf/physics/0701199v1.pdf.
+
+    Let \eps be the passage fraction. Then we have that:
+
+    P(\eps | n, k) = (n + 1)! / (k! (n - k)!) * \eps^k * (1 - \eps)^(n - k)
+
+    E[\eps] = Integral(\eps * P(\eps | n, k), 0, 1) = (k + 1) / (n + 2)
+
+    This is a biased estimator of the efficiency. An unbiased estimator is the solution 
+    to dP/d\eps = 0, which is \eps_{mp} = k / n (the same as the measured passage fraction).
+
+    The variance is given by:
+
+    V[\eps] = E[\eps^2] - E[\eps]^2 = (k + 1) / (n + 2) * ( (k + 2) / (n + 3) - (k + 1) / (n + 2))
+
+    Then the standard deviation is \sigma_{\eps} = \sqrt{V[\eps]}.
+
     """
-    
+
     if basecut is None:
         basecut = np.ones(len(x), dtype=bool)
-    
+
     if lgcequaldensitybins:
         histbins_equal = lambda var, nbin: np.interp(np.linspace(0, len(var), nbin + 1),
                                                      np.arange(len(var)),
                                                      np.sort(var))
         nbins = histbins_equal(x[basecut], nbins)
-    
+
     hist_vals_base, x_binned = np.histogram(x[basecut], bins=nbins)
     hist_vals, _ = np.histogram(x[basecut & cut], bins=x_binned)
-    
+
+    frac_binned_biased = (hist_vals + 1)/(hist_vals_base + 2)
+    frac_binned_err = np.sqrt(frac_binned_biased * ((hist_vals + 2)/(hist_vals_base + 3) - frac_binned_biased))
+
     hist_vals_base[hist_vals_base==0] = 1
-    
-    frac_binned = hist_vals/hist_vals_base
-    
-    return x_binned, frac_binned
+
+    frac_binned_mp = hist_vals/hist_vals_base
+
+    return x_binned, frac_binned_mp, frac_binned_biased, frac_binned_err

--- a/rqpy/plotting/_plotting.py
+++ b/rqpy/plotting/_plotting.py
@@ -302,10 +302,10 @@ def scatter(xvals, yvals, xlims=None, ylims=None, cuts=None, lgcrawdata=True, lg
     return fig, ax
 
 def passageplot(arr, cuts, basecut=None, nbins=100, lgcequaldensitybins=False, xlims=None, ylims=(0, 1),
-                lgceff=True, lgclegend=True, labeldict=None, ax=None, cmap="viridis"):
+                lgceff=True, lgclegend=True, labeldict=None, ax=None, cmap="viridis", showerrorbar=False):
     """
     Function to plot histogram of RQ data with multiple cuts.
-    
+
     Parameters
     ----------
     arr : array_like
@@ -342,28 +342,31 @@ def passageplot(arr, cuts, basecut=None, nbins=100, lgcequaldensitybins=False, x
         Option to pass an existing Matplotlib Axes object to plot over, if it already exists.
     cmap : str, optional
         The colormap to use for plotting each cut. Default is 'viridis'.
-    
+    showerrorbar : bool, optional
+        Boolean flag for also plotting the error bars for the passage fraction in each bin.
+        Default is False.
+
     Returns
     -------
     fig : Figure
         Matplotlib Figure object. Set to None if ax is passed as a parameter.
     ax : axes.Axes object
         Matplotlib Axes object
-        
+
     """
-    
+
     if not isinstance(cuts, list):
         cuts = [cuts]
-    
+
     labels = {'title'  : 'Passage Fraction Plot', 
               'xlabel' : 'variable', 
               'ylabel' : 'Passage Fraction'}
-    
-    
+
+
     for ii in range(len(cuts)):
-        
+
         num_str = str(ii+1)
-        
+
         if num_str[-1]=='1':
             num_str+="st"
         elif num_str[-1]=='2':
@@ -372,67 +375,91 @@ def passageplot(arr, cuts, basecut=None, nbins=100, lgcequaldensitybins=False, x
             num_str+="rd"
         else:
             num_str+="th"
-        
+
         labels[f"cut{ii}"] = num_str
-        
+
     if labeldict is not None:
         labels.update(labeldict)
-    
+
     if ax is None:
         fig, ax = plt.subplots(figsize=(9, 6))
     else:
         fig = None
-        
+
     ax.set_title(labels['title'])
     ax.set_xlabel(labels['xlabel'])
     ax.set_ylabel(labels['ylabel'])
 
     if basecut is None:
         basecut = np.ones(len(arr), dtype=bool)
-            
+
     colors = plt.cm.get_cmap(cmap)(np.linspace(0.1, 0.9, len(cuts)))
 
     ctemp = np.ones(len(arr), dtype=bool) & basecut
-    
+
     if xlims is None:
         xlimitcut = np.ones(len(arr), dtype=bool)
     else:
         xlimitcut = rp.inrange(arr, xlims[0], xlims[1])
-    
+
     for ii, cut in enumerate(cuts):
         oldsum = ctemp.sum()
-        
+
         if ii==0:
-            x_binned, passage_binned = rp.passage_fraction(arr, cut, basecut=ctemp & xlimitcut, nbins=nbins,
-                                                           lgcequaldensitybins=lgcequaldensitybins)
+            passage_output = rp.passage_fraction(arr,
+                                                 cut,
+                                                 basecut=ctemp & xlimitcut,
+                                                 nbins=nbins,
+                                                 lgcequaldensitybins=lgcequaldensitybins,
+                                                )
         else:
-            x_binned, passage_binned = rp.passage_fraction(arr, cut, basecut=ctemp & xlimitcut, nbins=x_binned)
-        
+            passage_output = rp.passage_fraction(arr,
+                                                 cut,
+                                                 basecut=ctemp & xlimitcut,
+                                                 nbins=x_binned,
+                                                )
+
+        x_binned = passage_output[0]
+        passage_binned = passage_output[1]
+
         ctemp = ctemp & cut
         newsum = ctemp.sum()
         cuteff = newsum/oldsum * 100
         label = f"Data passing {labels[f'cut{ii}']} cut"
-        
+
         if lgceff:
             label+=f", Total Passage: {cuteff:.1f}%"
-            
+
         if xlims is None:
             xlims = (x_binned.min()*0.9, x_binned.max()*1.1)
-        
+
         bin_centers = (x_binned[1:]+x_binned[:-1])/2
-        
+
         ax.hist(bin_centers, bins=x_binned, weights=passage_binned, histtype='step', 
                 color=colors[ii], label=label, linewidth=2)
-    
+
+        if showerrorbar:
+            passage_binned_biased = passage_output[2]
+            passage_binned_err = passage_output[3]
+
+            err_top = passage_binned_biased + passage_binned_err
+            err_bottom = passage_binned_biased - passage_binned_err
+
+            err_top = np.pad(err_top, (0, 1), mode='constant', constant_values=(0, err_top[-1]))
+            err_bottom = np.pad(err_bottom, (0, 1), mode='constant', constant_values=(0, err_bottom[-1]))
+
+            ax.fill_between(x_binned, err_top, y2=err_bottom, step='post',
+                            linewidth=1, alpha=0.5, color=colors[ii])
+
     ax.set_xlim(xlims)
     ax.set_ylim(ylims)
     ax.ticklabel_format(style='sci', axis='x', scilimits=(0, 0))
     ax.tick_params(which="both", direction="in", right=True, top=True)
     ax.grid(linestyle="dashed")
-    
+
     if lgclegend:
         ax.legend(loc="best")
-    
+
     return fig, ax
 
 

--- a/rqpy/plotting/_plotting.py
+++ b/rqpy/plotting/_plotting.py
@@ -302,7 +302,8 @@ def scatter(xvals, yvals, xlims=None, ylims=None, cuts=None, lgcrawdata=True, lg
     return fig, ax
 
 def passageplot(arr, cuts, basecut=None, nbins=100, lgcequaldensitybins=False, xlims=None, ylims=(0, 1),
-                lgceff=True, lgclegend=True, labeldict=None, ax=None, cmap="viridis", showerrorbar=False):
+                lgceff=True, lgclegend=True, labeldict=None, ax=None, cmap="viridis",
+                showerrorbar=False, nsigmaerrorbar=1):
     """
     Function to plot histogram of RQ data with multiple cuts.
 
@@ -345,6 +346,8 @@ def passageplot(arr, cuts, basecut=None, nbins=100, lgcequaldensitybins=False, x
     showerrorbar : bool, optional
         Boolean flag for also plotting the error bars for the passage fraction in each bin.
         Default is False.
+    nsigmaerrorbar : float, optional
+        The number of sigma to show for the error bars if `showerrorbar` is True. Default is 1.
 
     Returns
     -------
@@ -427,6 +430,9 @@ def passageplot(arr, cuts, basecut=None, nbins=100, lgcequaldensitybins=False, x
         cuteff = newsum/oldsum * 100
         label = f"Data passing {labels[f'cut{ii}']} cut"
 
+        if showerrorbar:
+            label += f" $\pm$ {nsigmaerrorbar}$\sigma$"
+
         if lgceff:
             label+=f", Total Passage: {cuteff:.1f}%"
 
@@ -442,8 +448,8 @@ def passageplot(arr, cuts, basecut=None, nbins=100, lgcequaldensitybins=False, x
             passage_binned_biased = passage_output[2]
             passage_binned_err = passage_output[3]
 
-            err_top = passage_binned_biased + passage_binned_err
-            err_bottom = passage_binned_biased - passage_binned_err
+            err_top = passage_binned_biased + passage_binned_err * nsigmaerrorbar
+            err_bottom = passage_binned_biased - passage_binned_err * nsigmaerrorbar
 
             err_top = np.pad(err_top, (0, 1), mode='constant', constant_values=(0, err_top[-1]))
             err_bottom = np.pad(err_bottom, (0, 1), mode='constant', constant_values=(0, err_bottom[-1]))


### PR DESCRIPTION
I've added the passage fraction error information to `rqpy.passage_fraction`. The standard deviation and the biased estimator are returned, based on the probability distribution in [this paper](https://arxiv.org/pdf/physics/0701199v1.pdf) (see Eq. 12).

There are now four returned values for `rqpy.passage_fraction`, the x values, the measured passage fraction, the biased estimator of the passage fraction, and the standard deviation of the passage fraction (centered on the biased estimator).

I've also updated the `rqpy.passageplot` function to have the option of plotting the 1-sigma error of the passage fraction, via the `showerrorbar` optional argument.

This PR is related to Issue #69.