### PR TITLE
Add functional form for trigger efficiency

### DIFF
--- a/rqpy/sim/_trig_sim.py
+++ b/rqpy/sim/_trig_sim.py
@@ -1,4 +1,4 @@
-from scipy import signal
+from scipy import signal, special
 import qetpy as qp
 import rqpy as rp
 import numpy as np
@@ -12,7 +12,39 @@ if HAS_TRIGSIM:
     import trigsim
 
 
-__all__ = ["TrigSim"]
+__all__ = [
+    "TrigSim",
+    "trigger_efficiency",
+]
+
+
+def trigger_efficiency(x, offset, width):
+    """
+    The expected functional form of the trigger efficiency, using an Error Function.
+
+    Parameters
+    ----------
+    x : array_like
+        The x-values at which to calculate the trigger efficiency, e.g. energy values.
+    offset : float
+        The offset of the trigger efficiency curve, such that the midpoint of the Error
+        Function occurs at this point. Should have same units as `x`.
+    width : float
+        The width of the Error Function, with the same units as `x`. This width can be
+        thought of as the width of the Gaussian distribution that, when convolved with
+        a step function placed at `offset`, gives us the resulting Error Function.
+
+    Returns
+    -------
+    trig_eff : array_like
+        The corresponding trigger efficiency (between 0 and 1) for each value of the
+        inputted `x`.
+
+    """
+
+    trig_eff = (1 - special.erf((offset - x) / (np.sqrt(2) * width))) / 2
+
+    return trig_eff
 
 
 class TrigSim(object):


### PR DESCRIPTION
I've added to `rqpy.sim` the function `trigger_efficiency`, which is the expected functional form of the trigger efficiency (comes from the convolution of a step function with a Gaussian). 

![](https://latex.codecogs.com/gif.latex?f%28x%29%20%3D%20%5Cfrac%7B1%7D%7B2%7D%5Cbigg%281-%5Cmathrm%7Berf%7D%5Cbigg%28%5Cfrac%7B%5Cmathrm%7Boffset%7D-x%7D%7B%5Csqrt%7B2%7D%20%5Ctimes%20%5Cmathrm%7Bwidth%7D%7D%5Cbigg%29%5Cbigg%29)