### PR TITLE
Added the calculation of the Trigger Time to the TrigSim

### DIFF
--- a/rqpy/sim/_trig_sim.py
+++ b/rqpy/sim/_trig_sim.py
@@ -50,10 +50,10 @@ def trigger_efficiency(x, offset, width):
 class TrigSim(object):
     """
     Class for setting up the DCRC FIR filter trigger simulation.
-    
+
     Attributes
     ----------
-    trig : Object
+    _Trigger : Object
         The `trigsim.Trigger` object which is used to build and run the FIR filter.
     input_psds : list
         The input power spectral density for the data, re-arranged for input into the FIR
@@ -63,7 +63,7 @@ class TrigSim(object):
         and re-arranged for input into the FIR filter code.
     fs : float
         The digitization rate of the data in Hz.
-    lgc_can_run_trigger : bool
+    can_run_trigger : bool
         A boolean flag for whether or not the `TrigSim.trigger` method can be run.
     which_channel : int
         The channel that the FIR filter will be triggering. Always set to zero, should not be
@@ -71,13 +71,18 @@ class TrigSim(object):
     of_coeffs : ndarray
         The coefficients of the FIR filter that will be applied to the downsampled
         data.
-    
+    _resolution : list
+        The calculated resolution of the FIR filter.
+    threshold : int
+        The threshold to set for triggering on pulses, should be in the arbitrary units of the
+        filter.
+
     """
-    
-    def __init__(self, psd, template, fs):
+
+    def __init__(self, psd, template, fs, fir_bits_out=32, fir_discard_msbs=4):
         """
         Initialization of the TrigSim class.
-        
+
         Parameters
         ----------
         psd : ndarray
@@ -88,16 +93,25 @@ class TrigSim(object):
             height of 1.
         fs : float
             The digitization rate of the data in Hz.
-        
+        fir_bits_out : int, optional
+            The number of bits to use in the integer values of the FIR. Default is 32, corresponding
+            to 32-bit integer trigger amplitudes. This is the recommended value, smaller values
+            may result in saturation fo the trigger amplitude (where the true amplitude would be
+            larger than the largest integer).
+        fir_discard_msbs : int, optional
+            The FIR pre-truncation shift of the bits for the FIR module. Default is 4, which is the
+            recommended value.
+
         """
-        
+
         if not HAS_TRIGSIM:
             raise ImportError("Cannot run the trigger simulation because trigsim is not installed.")
-        
+
         self.input_psds = [psd]*12 + [np.ones(4*len(psd))]*4
         self.input_pulse_shapes = [template]*12 + [np.zeros(4*template.shape[0])]*4
         self.fs = fs
-        self.lgc_can_run_trigger = False
+        self.can_run_trigger = False
+        self.threshold = 0
 
         raw_LC_coeffs = np.zeros((4,16))
         self.which_channel = 0
@@ -106,13 +120,13 @@ class TrigSim(object):
         TrL_requires = np.zeros((8,16), dtype=bool)
         TrL_vetos = np.zeros((8,16), dtype=bool)
 
-        self.trig = trigsim.Trigger(bits_phonon=16, bits_charge=16,
+        self._Trigger = trigsim.Trigger(bits_phonon=16, bits_charge=16,
                                     phonon_DF_R=16, phonon_DF_N=3, phonon_DF_M=1, phonon_start=0,
                                     charge_DF_R=64, charge_DF_N=3, charge_DF_M=1, charge_start=0,
                                     LC_coeffs=LC_coeffs, LC_bits_out=46,
                                     LC_bits_coeff=8, LC_discard_MSBs=[0,0,0,0],
-                                    FIR_coeffs=np.zeros((4,1024), 'i8'), FIR_bits_out=32, 
-                                    FIR_bits_coeff=16, FIR_discard_MSBs=[4,0,0,0],
+                                    FIR_coeffs=np.zeros((4,1024), 'i8'), FIR_bits_out=fir_bits_out, 
+                                    FIR_bits_coeff=16, FIR_discard_MSBs=[fir_discard_msbs,0,0,0],
                                     ThL_selectors=np.array([0,1,2,3,1,1,2,3], dtype='uint'),
                                     ThL_activation_thresholds   = (2**15 - 1)*np.ones(8, int),
                                     ThL_deactivation_thresholds = np.zeros(8, int),
@@ -123,26 +137,28 @@ class TrigSim(object):
                                     TrL_requires=TrL_requires, TrL_vetos=TrL_vetos,
                                     TrL_prescales=np.ones(8, dtype='float'))
         
-        self.of_coeffs = self.trig.build_OF_coeffs(self.input_psds, self.input_pulse_shapes)
-        self.trig.set_FIR_coeffs(self.of_coeffs)
-    
+        self.of_coeffs = self._Trigger.build_OF_coeffs(self.input_psds, self.input_pulse_shapes)
+        self._Trigger.set_FIR_coeffs(self.of_coeffs)
+
     def resolution(self):
         """
         Method for calculation the resolution of the FIR filter in the arbitrary units of the filter.
-        
+
         Returns
         -------
         resolution : ndarray
             The resolution of the FIR filter.
-        
+
         """
+
+        self._resolution = self._Trigger.resolution(self.input_psds, deltaT_phonon=1/self.fs)
         
-        return self.trig.resolution(self.input_psds, deltaT_phonon=1/self.fs)
-    
+        return self._resolution
+
     def set_threshold(self, threshold):
         """
         Method for calculation the resolution of the FIR filter in the arbitrary units of the filter.
-        
+
         Parameters
         ----------
         threshold : float
@@ -155,37 +171,39 @@ class TrigSim(object):
         calculate the resolution of the FIR filter using the `TrigSim.resolution` method. The output
         of that function times the number of standard deviations desired can then be directly passed 
         to this function.
-        
+
         Examples
         --------
         >>> import rqpy as rp
-        
+
         Load the PSD, template, and fs for passing to `TrigSim`.
-        
+
         >>> psd, template, fs = my_load_function('/path/to/data/file.ext')
         >>> TS = rp.sim.TrigSim(psd, template, fs)
         >>> resolution = TS.resolution()
-        
+
         Set the treshold to a 5-sigma threshold.
-        
-        >>> TS.set_threshold(5*resolution)
-        
+
+        >>> TS.set_threshold(5*resolution[0])
+
         Now the `TrigSim.trigger` method can be run on some data, where we have a 5-sigma trigger
         threshold.
-        
+
         """
-        
+
+        self.threshold = threshold
+
         if np.isscalar(threshold):
             threshold = (~np.all(~self.of_coeffs, axis=1)).astype(float)*threshold
-        
-        self.trig.ThL.ThLs[self.which_channel].set_thresholds(np.int64(threshold), 0)
-        
-        self.lgc_can_run_trigger = True
-        
+
+        self._Trigger.ThL.ThLs[self.which_channel].set_thresholds(np.int64(threshold), 0)
+
+        self.can_run_trigger = True
+
     def trigger(self, x, k=12):
         """
         Method for sending a trace to run the trigger simulation on.
-        
+
         Parameters
         ----------
         x : ndarray
@@ -194,12 +212,16 @@ class TrigSim(object):
         k : int, optional
             The bin number to start the FIR filter at. Since the filter downsamples the data
             by a factor of 16, the starting bin has a small effect on the calculated amplitude.
-        
+
         Returns
         -------
         triggeramp : int
             The trigger amplitude of the pulse as calculated by the FIR filter, in the arbitrary 
             units of the filter. Taken from the maximum amplitude in the trace.
+        triggertime : float
+            The time of the triggered pulse as calculated by the FIR filter, in s. Taken as the bin
+            number of the maximum amplitude within the valid part of the trace divided by the
+            downsampled digitization rate.
         fir_out : ndarray
             The complete, filtered trace corresponding to the inputted trace, in the arbitrary
             units of the filter.
@@ -209,23 +231,26 @@ class TrigSim(object):
         ValueError
             If the `TrigSim.set_threshold` method was not used to set the trigger threshold,
             then an error is thrown because the trigger is not properly set up.
-        
+
         """
-        
-        if not self.lgc_can_run_trigger:
+
+        if not self.can_run_trigger:
             raise ValueError("The threshold was not set, please use the TrigSim.set_threshold method.")
-        
+
         input_traces = [(x[k:] - 32768).astype('int64')] + [np.zeros(len(x[k:]),dtype='int64')]*11 + \
                        [np.zeros(4*len(x[k:]),dtype='int64')]*4
-        
-        self.trig.reset()
-        
-        pipe = trigsim.pipeline(self.trig.DF, self.trig.LC, self.trig.LC_trunc, 
-                                 self.trig.FIR, self.trig.FIR_trunc)
-        
-        fir_out = pipe.send(input_traces)
-        
-        triggeramp = fir_out[0, 1024:].max()
-        
-        return triggeramp, fir_out
 
+        self._Trigger.reset()
+
+        pipe = trigsim.pipeline(self._Trigger.DF, self._Trigger.LC, self._Trigger.LC_trunc, 
+                                self._Trigger.FIR, self._Trigger.FIR_trunc)
+
+        fir_out = pipe.send(input_traces)
+
+        if any(fir_out[0, 1024:] > self.threshold):
+            triggeramp = fir_out[0, 1024:].max()
+            triggertime = (np.argmax(fir_out[0, 1024:]) + 512 + k / 16) / (self.fs / 16)
+
+            return triggeramp, triggertime, fir_out
+        else:
+            return 0, 0, fir_out


### PR DESCRIPTION
I added to `rqpy.sim.TrigSim` a couple of features/changes:
- The trigger time is now returned by `TrigSim.trigger`
- renamed some attributes to create less confusion
- made fir_bits_out and fir_discard_msbs optional arguments, as they may change depending on how the trigger was set up

I also added the ability to pass `templates` and `psds` to `rqpy.process.SetupRQ` as `numpy.ndarray` type variables. This change is also backwards compatible, so the old way of uploading lists will still work.