### PR TITLE
Add fix for using only the valid region of the FIR trace

### DIFF
--- a/rqpy/sim/_trig_sim.py
+++ b/rqpy/sim/_trig_sim.py
@@ -249,7 +249,7 @@ class TrigSim(object):
 
         bins_to_keep = (len(x) - k)//16 - 1024
 
-        if any(fir_out[0, -bins_to_keep:] > self.threshold):
+        if any(fir_out[0, -bins_to_keep:] >= self.threshold):
             triggeramp = fir_out[0, -bins_to_keep:].max()
             triggertime = (np.argmax(fir_out[0, -bins_to_keep:]) + 512 + k / 16) / (self.fs / 16)
 

--- a/rqpy/sim/_trig_sim.py
+++ b/rqpy/sim/_trig_sim.py
@@ -247,10 +247,12 @@ class TrigSim(object):
 
         fir_out = pipe.send(input_traces)
 
-        if any(fir_out[0, 1024:] >= self.threshold):
-            triggeramp = fir_out[0, 1024:].max()
-            triggertime = (np.argmax(fir_out[0, 1024:]) + 512 + k / 16) / (self.fs / 16)
+        bins_to_keep = (len(x) - k)//16 - 1024
 
-            return triggeramp, triggertime, fir_out
+        if any(fir_out[0, -bins_to_keep:] > self.threshold):
+            triggeramp = fir_out[0, -bins_to_keep:].max()
+            triggertime = (np.argmax(fir_out[0, -bins_to_keep:]) + 512 + k / 16) / (self.fs / 16)
+
+            return triggeramp, triggertime, fir_out[0, -bins_to_keep:]
         else:
-            return 0, 0, fir_out
+            return 0, 0, fir_out[0, -bins_to_keep:]


### PR DESCRIPTION
In the previous version of the Trigger Simulation, the L2 trigger used one extra bin than it should have for the valid part of the FIR trace. I added a fix so that we no longer use the extra bin, which gave us 100% matching with data.