### PR TITLE
Feature/h5saving

### DIFF
--- a/rqpy/io/_load.py
+++ b/rqpy/io/_load.py
@@ -543,7 +543,7 @@ def load_h5_dump(path, lgcskip_empty=True, lgcreturndict=False):
     -------
     traces : ndarray
         Array of traces in the specified dump. Dimensions are (number of traces, number of channels, bins in each trace)
-    info_dict : dict
+    info_dict : dict, optional
         Dictionary that contains extra information on each event. Includes timing and trigger information.
         The keys in the dictionary are as follows.
             'eventnumber' : The event number for each event

--- a/rqpy/io/_load.py
+++ b/rqpy/io/_load.py
@@ -285,9 +285,9 @@ def get_traces_midgz(path, channels, det, convtoamps=None, lgcskip_empty=True, l
         are desired, convtoamps should be set to 1. Default is None, which will call get_trace_gain() to get the
         conversion to amps
     lgcskip_empty : bool, optional
-        Boolean flag on whether or not to skip empty events. Should be set to false if user only wants the traces.
+        Boolean flag on whether or not to skip empty events. Should be set to True if user only wants the traces.
         If the user also wants to pull extra timing information (primarily for live time calculations), then set
-        to True. Default is True.
+        to False. Default is True.
     lgcreturndict : bool, optional
         Boolean flag on whether or not to return the info_dict that has extra information on every event.
         By default, this is False
@@ -532,9 +532,9 @@ def load_h5_dump(path, lgcskip_empty=True, lgcreturndict=False):
     path : str
         Absolute path to dump of traces
     lgcskip_empty : bool, optional
-        Boolean flag on whether or not to skip empty events. Should be set to false if user only wants the traces.
+        Boolean flag on whether or not to skip empty events. Should be set to True if user only wants the traces.
         If the user also wants to pull extra timing information (primarily for live time calculations), then set
-        to True. Default is True.
+        to False. Default is True.
     lgcreturndict : bool, optional
         Boolean flag on whether or not to return the info_dict that has extra information on every event.
         By default, this is False

--- a/rqpy/io/_load.py
+++ b/rqpy/io/_load.py
@@ -523,7 +523,7 @@ def get_traces_npz(path):
         
     return traces, info_dict
 
-def load_h5_dump(path, lgcreturndict=False):
+def load_h5_dump(path, lgcskip_empty=True, lgcreturndict=False):
     """
     Function to load HDF5 dumps
     
@@ -531,6 +531,10 @@ def load_h5_dump(path, lgcreturndict=False):
     ----------
     path : str
         Absolute path to dump of traces
+    lgcskip_empty : bool, optional
+        Boolean flag on whether or not to skip empty events. Should be set to false if user only wants the traces.
+        If the user also wants to pull extra timing information (primarily for live time calculations), then set
+        to True. Default is True.
     lgcreturndict : bool, optional
         Boolean flag on whether or not to return the info_dict that has extra information on every event.
         By default, this is False
@@ -556,6 +560,12 @@ def load_h5_dump(path, lgcreturndict=False):
     
     info_dict = dd.io.load(path)
     traces = info_dict.pop('traces')
+    if lgcskip_empty:
+        cchans = ~np.all(traces[:,:,:] == 0, axis=-1)
+        cut = np.all(cchans, axis = -1)
+        traces = traces[cut]
+        for key in info_dict:
+            info_dict[key] = info_dict[key][cut]
     if lgcreturndict:
         return traces, info_dict
     return traces

--- a/rqpy/io/_save.py
+++ b/rqpy/io/_save.py
@@ -142,7 +142,7 @@ def saveevents_midgz(events, settings, savepath, savename, dumpnum):
     mywriter.close_file()  
 
 
-def convert_midgz_to_h5(path, savepath, channels, det, lgcskip_empty=True):
+def convert_midgz_to_h5(path, savepath, channels, det, lgcskip_empty=False):
     """
     Function to convert raw traces and event numbers for a single dump from mid.gz to HDF5.
     
@@ -168,7 +168,7 @@ def convert_midgz_to_h5(path, savepath, channels, det, lgcskip_empty=True):
     lgcskip_empty : bool, optional
         Boolean flag on whether or not to skip empty events. Should be set to false if user only wants the traces.
         If the user also wants to pull extra timing information (primarily for live time calculations), then set
-        to True. Default is True.
+        to True. Default is False.
     
     Returns
     -------
@@ -178,13 +178,13 @@ def convert_midgz_to_h5(path, savepath, channels, det, lgcskip_empty=True):
     
     if not isinstance(path, list):
         path = [path]
-        
+
     savename = []
     for p in path:
         savename.append(p.split('/')[-1].split('.')[0])
-    
+
     for jj, p in enumerate(path):
-        x, info_dict = get_traces_midgz(p, channels, det, lgcreturndict=True)
+        x, info_dict = get_traces_midgz(p, channels, det, lgcskip_empty=False, lgcreturndict=True)
         for key in info_dict:
             info_dict[key] = np.asarray(info_dict[key])
         info_dict['traces'] = x

--- a/rqpy/io/_save.py
+++ b/rqpy/io/_save.py
@@ -166,9 +166,9 @@ def convert_midgz_to_h5(path, savepath, channels, det, lgcskip_empty=False):
         the channel names. If a string is inputted and there are multiple channels, then it 
         is assumed that the detector name is the same for each channel.
     lgcskip_empty : bool, optional
-        Boolean flag on whether or not to skip empty events. Should be set to false if user only wants the traces.
+        Boolean flag on whether or not to skip empty events. Should be set to True if user only wants the traces.
         If the user also wants to pull extra timing information (primarily for live time calculations), then set
-        to True. Default is False.
+        to False. Default is False.
     
     Returns
     -------
@@ -184,7 +184,7 @@ def convert_midgz_to_h5(path, savepath, channels, det, lgcskip_empty=False):
         savename.append(p.split('/')[-1].split('.')[0])
 
     for jj, p in enumerate(path):
-        x, info_dict = get_traces_midgz(p, channels, det, lgcskip_empty=False, lgcreturndict=True)
+        x, info_dict = get_traces_midgz(p, channels, det, lgcskip_empty=lgcskip_empty, lgcreturndict=True)
         for key in info_dict:
             info_dict[key] = np.asarray(info_dict[key])
         info_dict['traces'] = x


### PR DESCRIPTION
Added function to convert .mid.gz traces to .h5 using `deepdish`. All the metadata associated with the traces is also saved (i.e. the `info_dict` returned by `rqpy.io.get_traces_midgz`). Empty events can be skipped or included when converting to .h5. They can also be skipped of included when being loaded from the .h5 file. 

Also, I added in the option to have `rqpy.io.get_traces_midgz` call `rqpy.io.get_trace_gain` if the `convtoamps` parameter is set to `None`. This resolves Issue #https://github.com/ucbpylegroup/RQpy/issues/55
This should be mostly be backwards compatible, except in the case where someone is intending the returned traces to be in ADC units and left `convtoamps` as its previous default of 1, which I believe would not effect any of our current code?

TODO: we now need to add in the functionality for `getrandevents` to work with the .h5 files, but this should be done in a different PR. 

Also, don't delete this branch yet as I will continue dev off of this