### PR TITLE
Add smear option to RatePlot plotting

### DIFF
--- a/rqpy/limit/_limit.py
+++ b/rqpy/limit/_limit.py
@@ -274,7 +274,7 @@ def gauss_smear(x, f, res, nres=1e5, gauss_width=10):
 
 
 def optimuminterval(eventenergies, effenergies, effs, masslist, exposure,
-                    tm="Si", res=None, verbose=False):
+                    tm="Si", res=None, gauss_width=10, verbose=False):
     """
     Function for running Steve Yellin's Optimum Interval code on an inputted spectrum and efficiency curve.
 
@@ -293,10 +293,13 @@ def optimuminterval(eventenergies, effenergies, effs, masslist, exposure,
     tm : str, int, optional
         The target material of the detector. Can be passed as either the atomic symbol, the
         atomic number, or the full name of the element. Default is 'Si'.
-    res : float, optional
+    res : float, NoneType, optional
         The detector resolution in units of keV. If passed, then the differential scattering
         rate of the dark matter is convoluted by a gaussian with width `res`, which results
         in a smeared spectrum. If left as None, no smearing is performed.
+    gauss_width : float, optional
+        If `res` is not None, this is the number of standard deviations of the Gaussian
+        distribution that the smearing will go out to. Default is 10.
     verbose : bool, optional
         If True, then the algorithm prints out the number of mass that it is currently calculating
         the limit for. If False, no information is printed. Default is False.
@@ -352,7 +355,7 @@ def optimuminterval(eventenergies, effenergies, effs, masslist, exposure,
         init_rate = drde(en_interp, mass, sigma0, tm=tm)
 
         if res is not None:
-            init_rate = gauss_smear(en_interp, init_rate, res)
+            init_rate = gauss_smear(en_interp, init_rate, res, gauss_width=gauss_width)
 
         rate = init_rate * curr_exp(en_interp)
 

--- a/rqpy/plotting/_core_plotting.py
+++ b/rqpy/plotting/_core_plotting.py
@@ -730,9 +730,10 @@ class RatePlot(RQpyPlot):
         self.ax.step(bin_cen, rate, where='mid', label=label, linestyle='-', **kwargs)
         self._update_colors("-")
         
-    def add_drde(self, masses, sigmas, tm="Si", npoints=1000, **kwargs):
+    def add_drde(self, masses, sigmas, tm="Si", npoints=1000, smear_res=None, gauss_width=10, **kwargs):
         """
-        Method for plotting a single spectrum in evts/keV/kg/day from inputted data.
+        Method for plotting the expected dark matter spectrum for specified masses and
+        cross sections in evts/keV/kg/day.
 
         Parameters
         ----------
@@ -747,6 +748,13 @@ class RatePlot(RQpyPlot):
             atomic number, or the full name of the element. Default is 'Si'.
         npoints : int, optional
             The number of points to use in the dR/dE plot. Default is 1000.
+        smear_res : float, NoneType, optional
+            The width of the gaussian (1 standard deviation) to be used to smear differential
+            scatter rate in the plot. Should have units of keV. None by default, in which no
+            smearing is done.
+        gauss_width : float, optional
+            If `smear_res` is not None, this is the number of standard deviations of the Gaussian
+            distribution that the smearing will go out to. Default is 10.
         kwargs
             The keyword arguments to pass to `matplotlib.pyplot.plot`.
 
@@ -771,7 +779,11 @@ class RatePlot(RQpyPlot):
         xvals = np.linspace(self._energy_range[0], self._energy_range[1], npoints)
 
         for m, sig in zip(masses, sigmas):
-            self.ax.plot(xvals, rp.limit.drde(xvals, m, sig, tm=tm), linestyle='--',
+            drde = rp.limit.drde(xvals, m, sig, tm=tm)
+            if smear_res is not None:
+                drde = rp.limit.gauss_smear(xvals, drde, smear_res, gauss_width=gauss_width)
+
+            self.ax.plot(xvals, drde, linestyle='--',
                          label=f"DM Mass = {m:.2f} GeV, σ = {sig:.2e} cm$^2$",
                          **kwargs,
                         )

--- a/rqpy/plotting/_core_plotting.py
+++ b/rqpy/plotting/_core_plotting.py
@@ -730,7 +730,7 @@ class RatePlot(RQpyPlot):
         self.ax.step(bin_cen, rate, where='mid', label=label, linestyle='-', **kwargs)
         self._update_colors("-")
         
-    def add_drde(self, masses, sigmas, tm="Si", npoints=1000, smear_res=None, gauss_width=10, **kwargs):
+    def add_drde(self, masses, sigmas, tm="Si", npoints=1000, res=None, gauss_width=10, **kwargs):
         """
         Method for plotting the expected dark matter spectrum for specified masses and
         cross sections in evts/keV/kg/day.
@@ -748,12 +748,12 @@ class RatePlot(RQpyPlot):
             atomic number, or the full name of the element. Default is 'Si'.
         npoints : int, optional
             The number of points to use in the dR/dE plot. Default is 1000.
-        smear_res : float, NoneType, optional
+        res : float, NoneType, optional
             The width of the gaussian (1 standard deviation) to be used to smear differential
             scatter rate in the plot. Should have units of keV. None by default, in which no
             smearing is done.
         gauss_width : float, optional
-            If `smear_res` is not None, this is the number of standard deviations of the Gaussian
+            If `res` is not None, this is the number of standard deviations of the Gaussian
             distribution that the smearing will go out to. Default is 10.
         kwargs
             The keyword arguments to pass to `matplotlib.pyplot.plot`.
@@ -780,8 +780,8 @@ class RatePlot(RQpyPlot):
 
         for m, sig in zip(masses, sigmas):
             drde = rp.limit.drde(xvals, m, sig, tm=tm)
-            if smear_res is not None:
-                drde = rp.limit.gauss_smear(xvals, drde, smear_res, gauss_width=gauss_width)
+            if res is not None:
+                drde = rp.limit.gauss_smear(xvals, drde, res, gauss_width=gauss_width)
 
             self.ax.plot(xvals, drde, linestyle='--',
                          label=f"DM Mass = {m:.2f} GeV, σ = {sig:.2e} cm$^2$",


### PR DESCRIPTION
Added to `rqpy.plotting.RatePlot.add_drde` the option to plot the smeared dRdE spectrum for a given DM mass/cross section.

Also added the ability to pass the width of the gaussian smearin to `rqpy.limit.optimuminterval`.