### PR TITLE
Specify direct convolve method in gauss_smear to avoid numerical errors

### DIFF
--- a/rqpy/limit/_limit.py
+++ b/rqpy/limit/_limit.py
@@ -266,7 +266,7 @@ def gauss_smear(x, f, res, nres=1e5, gauss_width=10):
     xgauss = np.arange(-gauss_width*res, gauss_width*res, spacing)
     gauss = stats.norm.pdf(xgauss, scale=res)
 
-    sce = signal.convolve(f2(x2), gauss, mode="full") * spacing
+    sce = signal.convolve(f2(x2), gauss, mode="full", method="direct") * spacing
     e_conv = np.arange(-gauss_width*res, gauss_width*res + x2[-1]-x2[0], spacing)
     s = interpolate.interp1d(e_conv, sce)
 


### PR DESCRIPTION
This fixes a possible bug in `rqpy.limit.gauss_smear` where the `scipy.signal.convolve` function would induce numerical errors when using `method="fft"`. This would happen because, by default, the function uses `method="auto"`, which will be used for large arrays. In this case, sections of the smeared differential scattering rate that should be zero would no longer be zero, which could result in limits from the `rqpy.limit.optimuminterval` code that are artificially lower.

The fix is to simply specify `method="direct"`, which will give a small performance hit, but correctly deal with this case. This method does the convolution based on array multiplication, i.e. following the definition of convolution.