### PR TITLE
Add smearing label to Gaussian smeared dRdE curves

### DIFF
--- a/rqpy/plotting/_core_plotting.py
+++ b/rqpy/plotting/_core_plotting.py
@@ -780,11 +780,15 @@ class RatePlot(RQpyPlot):
 
         for m, sig in zip(masses, sigmas):
             drde = rp.limit.drde(xvals, m, sig, tm=tm)
+            label = f"DM Mass = {m:.2f} GeV, σ = {sig:.2e} cm$^2$"
             if res is not None:
                 drde = rp.limit.gauss_smear(xvals, drde, res, gauss_width=gauss_width)
+                label += f"\nWith {gauss_width}$\sigma_E$ Smearing"
 
-            self.ax.plot(xvals, drde, linestyle='--',
-                         label=f"DM Mass = {m:.2f} GeV, σ = {sig:.2e} cm$^2$",
+            self.ax.plot(xvals,
+                         drde,
+                         linestyle='--',
+                         label=label,
                          **kwargs,
                         )
 


### PR DESCRIPTION
I added a small fix that labels how much smearing was doing to dRdE curves in `rqpy.RatePlot`. Makes the labels less confusing.

This is a small enough change that l will merge without waiting for a review... Sorry @cwfink!