### PR TITLE
Add a file for storing constants

### DIFF
--- a/rqpy/__init__.py
+++ b/rqpy/__init__.py
@@ -8,3 +8,4 @@ from . import io
 from . import sim
 from . import utils
 from . import limit
+from . import constants

--- a/rqpy/constants/__init__.py
+++ b/rqpy/constants/__init__.py
@@ -1,0 +1,2 @@
+from scipy.constants import *
+from ._constants import *

--- a/rqpy/constants/_constants.py
+++ b/rqpy/constants/_constants.py
@@ -1,0 +1,8 @@
+"""
+Collection of physical constants used in `rqpy` functions that do not exist in `scipy.constants`.
+"""
+
+v0_sun = 220e3 # sun velocity about galactic center [m/s]
+ve_orbital = 232e3 # mean orbital velocity of Earth [m/s]
+vesc_galactic = 544e3 # galactic escape velocity [m/s]
+rho0_dm = 0.3 # local DM density [GeV/cm^3]

--- a/rqpy/limit/_limit.py
+++ b/rqpy/limit/_limit.py
@@ -4,9 +4,10 @@ import time
 import os
 from pathlib import Path
 import contextlib
-from scipy import stats, signal, interpolate, constants, special
+from scipy import stats, signal, interpolate, special
 
 import rqpy as rp
+from rqpy import constants
 from rqpy.limit import _upperlim
 import mendeleev
 
@@ -191,10 +192,10 @@ def drde(q, m_dm, sig0, tm='Si'):
 
     q = np.atleast_1d(q) # convert to recoil energy in keV
 
-    v0 = 220e3 # sun velocity about glactic center [m/s]
-    ve = 232e3 # mean orbital velocity of Earch [m/s]
-    vesc = 544e3 # galactic escape velocity [m/s]
-    rho0 = 0.3 # local DM density [GeV/cm^3]
+    v0 = constants.v0_sun # sun velocity about galactic center [m/s]
+    ve = constants.ve_orbital # mean orbital velocity of Earth [m/s]
+    vesc = constants.vesc_galactic # galactic escape velocity [m/s]
+    rho0 = constants.rho0_dm # local DM density [GeV/cm^3]
 
     a = mendeleev.element(tm).atomic_weight
     mn = constants.atomic_mass * constants.c**2 / constants.e * 1e-9 # nucleon mass (1 amu) [GeV]


### PR DESCRIPTION
I've added a submodule for storing frequently used constants, as detailed below. I'm also importing the constants from SciPy for convenience.

- Add the `rqpy.constants` submodule
- Import all constants stored in `scipy.constants` for convenience (in the `__init__.py`)
- Add some frequently used dark matter constants to `_constants.py`
- Change `rqpy/limit/_limit.py` to use this new submodule