### PR TITLE
Add 2D Gaussian Smearing to OI Limit Code

### DIFF
--- a/rqpy/limit/_limit.py
+++ b/rqpy/limit/_limit.py
@@ -15,6 +15,7 @@ import mendeleev
 __all__ = ["optimuminterval",
            "gauss_smear",
            "drde",
+           "drde_max_q",
            "helmfactor",
            "upperlim",
           ]
@@ -232,6 +233,36 @@ def drde(q, m_dm, sig0, tm='Si'):
 
     return rate
 
+def drde_max_q(m_dm, tm='Si'):
+    """
+    Function for calculating the energy corresponding to the largest nonzero value of the differential rate,
+    i.e. `rqpy.limit.drde`.
+
+    Parameters
+    ----------
+    m_dm : float, ndarray
+        The dark matter mass at which to calculate the expected differential
+        scattering rate. Expected units are GeV.
+    tm : str, int, optional
+        The target material of the detector. Can be passed as either the atomic symbol, the
+        atomic number, or the full name of the element. Default is 'Si'.
+
+    Returns
+    -------
+    qmax : float, ndarray
+        The energy corresponding to the largest nonzero value of the differential rate, where recoil energies
+        above this value will have a differential rate of zero.
+
+    """
+
+    a = mendeleev.element(tm).atomic_weight
+    mn = constants.atomic_mass * constants.c**2 / constants.e * 1e-9 # nucleon mass (1 amu) [GeV]
+    mtarget = a * mn # nucleon mass for tm [GeV]
+    r = 4 * m_dm * mtarget / (m_dm + mtarget)**2 # unitless reduced mass parameter
+    e0 = 0.5 * m_dm * (constants.v0_sun / constants.c)**2 * 1e6 # kinetic energy of dark matter [keV]
+    qmax = e0 * r * ((constants.vesc_galactic + constants.ve_orbital) / constants.v0_sun)**2
+
+    return qmax
 
 def gauss_smear(x, f, res, nres=1e5, gauss_width=10):
     """

--- a/rqpy/limit/_limit.py
+++ b/rqpy/limit/_limit.py
@@ -582,8 +582,9 @@ def drde_gauss_smear2d(x, cov, delta, m_dm, sig0, nsig=3, tm="Si"):
             out[ii] = np.sum(Z) * d1 * d2
 
     return out
+
 def optimuminterval_2dsmear(eventenergies, masslist, exposure, cov, delta,
-                            tm="Si", nsig=3, verbose=False):
+                            tm="Si", nsig=3, verbose=False, npts=1e3):
     """
     Function for running Steve Yellin's Optimum Interval code on an inputted spectrum, using the
     two-dimensional normal distribution defined by the inputted covariance matrix to model the
@@ -612,6 +613,9 @@ def optimuminterval_2dsmear(eventenergies, masslist, exposure, cov, delta,
     verbose : bool, optional
         If True, then the algorithm prints out the number of mass that it is currently calculating
         the limit for. If False, no information is printed. Default is False.
+    npts : float, optional
+        The number of energies at which to evaluate the smeared differential rate. Large values
+        result in long computation times. Default is 1e3.
 
     Returns
     -------
@@ -634,10 +638,10 @@ def optimuminterval_2dsmear(eventenergies, masslist, exposure, cov, delta,
 
     eventenergies = np.sort(eventenergies)
 
-    elow = max(0.001, min(effenergies))
-    ehigh = max(effenergies)
+    elow = max(0.001, min(eventenergies))
+    ehigh = max(eventenergies)
 
-    en_interp = np.logspace(np.log10(0.9 * elow), np.log10(1.1 * ehigh), 1e5)
+    en_interp = np.logspace(np.log10(0.9 * elow), np.log10(1.1 * ehigh), npts)
 
     delta_e = np.concatenate(([(en_interp[1] - en_interp[0])/2],
                               (en_interp[2:] - en_interp[:-2])/2,


### PR DESCRIPTION
I've added a couple functions that allow the use of the 2D Gaussian smearing to calculate a limit, as well as some other changes.

- Added the function `drde_max_q` for determining the largest recoil energy for nonzero dRdE given some dark matter mass
- Added the 2D gaussian smearing
- Added an optimum interval wrapper that uses the 2D gaussian smearing (easier to make it a new function)

This 2D Gaussian smearing is meant to correctly take into account correlations between two different energy estimators (e.g. a trigger energy and a reconstructed offline energy) when smearing out the dRdE with a detector resolution.