### PR TITLE
Calculate no delay amplitude for TrigSim, use windowcenter, update pileup processing

### DIFF
--- a/rqpy/process/_process_rq.py
+++ b/rqpy/process/_process_rq.py
@@ -1245,6 +1245,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
     if setup.do_trigsim[chan_num] and setup.trigger == chan_num:
         triggeramp_sim = np.zeros(len(signal))
         triggertime_sim = np.zeros(len(signal))
+        ofampnodelay_sim = np.zeros(len(signal))
 
     if any(readout_inds):
         # run the OF class for each trace
@@ -1368,6 +1369,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
                 res_trigsim = setup.TS.trigger(setup.signal_full[jj, chan_num], k=setup.trigsim_k)
                 triggeramp_sim[jj] = res_trigsim[0]
                 triggertime_sim[jj] = res_trigsim[1]
+                ofampnodelay_sim[jj] = res_trigsim[2]
 
     # save variables to dict
     if setup.do_chi2_nopulse[chan_num]:
@@ -1522,6 +1524,8 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
         rq_dict[f'triggeramp_sim_{chan}{det}'][readout_inds] = triggeramp_sim
         rq_dict[f'triggertime_sim_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'triggertime_sim_{chan}{det}'][readout_inds] = triggertime_sim
+        rq_dict[f'ofamp_nodelay_sim_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
+        rq_dict[f'ofamp_nodelay_sim_{chan}{det}'][readout_inds] = ofampnodelay_sim
 
     if any(setup.do_ofamp_shifted) and setup.trigger is not None:
         # do the shifted OF on each trace

--- a/rqpy/process/_process_rq.py
+++ b/rqpy/process/_process_rq.py
@@ -91,6 +91,11 @@ class SetupRQ(object):
         The length of the window (in bins), centered on the middle of the trace, to constrain 
         the possible time shift values to when doing the optimum filter fit with constrained time shifting. 
         Each value in the list specifies this attribute for each channel.
+    ofamp_constrained_windowcenter : list of int
+        The bin, relative to the center bin of the trace, on which the delay window
+        specified by `nconstrain` is centered. Default of 0 centers the delay window
+        in the center of the trace. Equivalent to centering the `nconstrain` window
+        on `self.nbins//2 + windowcenter`.
     ofamp_constrained_pulse_constraint : list of int
         Sets a constraint on the direction of the fitted pulse. If 0, then no constraint on the 
         pulse direction is set. If 1, then a positive pulse constraint is set for all fits. 
@@ -108,6 +113,11 @@ class SetupRQ(object):
         The length of the window (in bins), centered on the middle of the trace, outside of which to 
         constrain the possible time shift values to when searching for a pileup pulse using ofamp_pileup. Each 
         value in the list specifies this attribute for each channel.
+    ofamp_pileup_windowcenter : list of int
+        The bin, relative to the center bin of the trace, on which the delay window
+        specified by `nconstrain` is centered. Default of 0 centers the delay window
+        in the center of the trace. Equivalent to centering the `nconstrain` window
+        on `self.nbins//2 + windowcenter`.
     ofamp_pileup_pulse_constraint : list of int
         Sets a constraint on the direction of the fitted pulse. If 0, then no constraint on the 
         pulse direction is set. If 1, then a positive pulse constraint is set for all fits. 
@@ -139,6 +149,11 @@ class SetupRQ(object):
         The length of the window (in bins), centered on the middle of the trace, to constrain 
         the possible time shift values to when doing the optimum filter fit with fixed baseline. Each 
         value in the list specifies this attribute for each channel.
+    ofamp_baseline_windowcenter : list of int
+        The bin, relative to the center bin of the trace, on which the delay window
+        specified by `nconstrain` is centered. Default of 0 centers the delay window
+        in the center of the trace. Equivalent to centering the `nconstrain` window
+        on `self.nbins//2 + windowcenter`.
     ofamp_baseline_pulse_constraint : list of int
         Sets a constraint on the direction of the fitted pulse. If 0, then no constraint on the 
         pulse direction is set. If 1, then a positive pulse constraint is set for all fits. 
@@ -342,11 +357,13 @@ class SetupRQ(object):
         self.do_ofamp_constrained_smooth = [False]*self.nchan
         self.ofamp_constrained_lowfreqchi2 = True
         self.ofamp_constrained_nconstrain = [80]*self.nchan
+        self.ofamp_constrained_windowcenter = [0]*self.nchan
         self.ofamp_constrained_pulse_constraint = [0]*self.nchan
 
         self.do_ofamp_pileup = [True]*self.nchan
         self.do_ofamp_pileup_smooth = [False]*self.nchan
         self.ofamp_pileup_nconstrain = [80]*self.nchan
+        self.ofamp_pileup_windowcenter = [0]*self.nchan
         self.ofamp_pileup_pulse_constraint = [0]*self.nchan
 
         self.do_chi2_nopulse = [True]*self.nchan
@@ -358,6 +375,7 @@ class SetupRQ(object):
         self.do_ofamp_baseline = [False]*self.nchan
         self.do_ofamp_baseline_smooth = [False]*self.nchan
         self.ofamp_baseline_nconstrain = [80]*self.nchan
+        self.ofamp_baseline_windowcenter = [0]*self.nchan
         self.ofamp_baseline_pulse_constraint = [0]*self.nchan
 
         self.do_baseline = [True]*self.nchan
@@ -588,7 +606,7 @@ class SetupRQ(object):
         self._check_of()
 
     def adjust_ofamp_constrained(self, lgcrun=True, lgcrun_smooth=False, calc_lowfreqchi2=True, 
-                                 nconstrain=80, pulse_direction_constraint=0):
+                                 nconstrain=80, windowcenter=0, pulse_direction_constraint=0):
         """
         Method for adjusting the calculation of the optimum filter fit with constrained 
         time shifting.
@@ -613,6 +631,11 @@ class SetupRQ(object):
             fit with constrained time shifting. Can be set to a list of values, if the
             constrain window should be different for each channel. The length of the list should
             be the same length as the number of channels.
+        windowcenter : int, list of int, optional
+            The bin, relative to the center bin of the trace, on which the delay window
+            specified by `nconstrain` is centered. Default of 0 centers the delay window
+            in the center of the trace. Equivalent to centering the `nconstrain` window
+            on `self.nbins//2 + windowcenter`.
         pulse_direction_constraint : int, list of int, optional
             Sets a constraint on the direction of the fitted pulse. If 0, then no constraint on the
             pulse direction is set. If 1, then a positive pulse constraint is set for all fits.
@@ -625,6 +648,7 @@ class SetupRQ(object):
             lgcrun=lgcrun,
             lgcrun_smooth=lgcrun_smooth,
             nconstrain=nconstrain,
+            windowcenter=windowcenter,
             pulse_direction_constraint=pulse_direction_constraint,
         )
 
@@ -632,13 +656,13 @@ class SetupRQ(object):
         self.do_ofamp_constrained_smooth = lgcrun_smooth
         self.ofamp_constrained_lowfreqchi2 = calc_lowfreqchi2
         self.ofamp_constrained_nconstrain = nconstrain
-
+        self.ofamp_constrained_windowcenter = windowcenter
         self.ofamp_constrained_pulse_constraint = pulse_direction_constraint
 
         self._check_of()
 
     def adjust_ofamp_baseline(self, lgcrun=True, lgcrun_smooth=False, 
-                              nconstrain=80, pulse_direction_constraint=0):
+                              nconstrain=80, windowcenter=0, pulse_direction_constraint=0):
         """
         Method for adjusting the calculation of the optimum filter fit with fixed 
         baseline.
@@ -658,6 +682,11 @@ class SetupRQ(object):
             fit with fixed baseline. Can be set to a list of values, if the 
             constrain window should be different for each channel. The length of the list should
             be the same length as the number of channels.
+        windowcenter : int, list of int, optional
+            The bin, relative to the center bin of the trace, on which the delay window
+            specified by `nconstrain` is centered. Default of 0 centers the delay window
+            in the center of the trace. Equivalent to centering the `nconstrain` window
+            on `self.nbins//2 + windowcenter`.
         pulse_direction_constraint : int, list of int, optional
             Sets a constraint on the direction of the fitted pulse. If 0, then no constraint on the
             pulse direction is set. If 1, then a positive pulse constraint is set for all fits.
@@ -670,19 +699,20 @@ class SetupRQ(object):
             lgcrun=lgcrun,
             lgcrun_smooth=lgcrun_smooth,
             nconstrain=nconstrain,
+            windowcenter=windowcenter,
             pulse_direction_constraint=pulse_direction_constraint,
         )
 
         self.do_ofamp_baseline = lgcrun
         self.do_ofamp_baseline_smooth = lgcrun_smooth
         self.ofamp_baseline_nconstrain = nconstrain
-
+        self.ofamp_baseline_windowcenter = windowcenter
         self.ofamp_baseline_pulse_constraint = pulse_direction_constraint
 
         self._check_of()
 
     def adjust_ofamp_pileup(self, lgcrun=True, lgcrun_smooth=False, 
-                            nconstrain=80, pulse_direction_constraint=0):
+                            nconstrain=80, windowcenter=0, pulse_direction_constraint=0):
         """
         Method for adjusting the calculation of the pileup optimum filter fit.
 
@@ -700,6 +730,11 @@ class SetupRQ(object):
             pileup pulse using ofamp_pileup. Can be set to a list of values, if the constrain
             window should be different for each channel. The length of the list should
             be the same length as the number of channels.
+        windowcenter : int, list of int, optional
+            The bin, relative to the center bin of the trace, on which the delay window
+            specified by `nconstrain` is centered. Default of 0 centers the delay window
+            in the center of the trace. Equivalent to centering the `nconstrain` window
+            on `self.nbins//2 + windowcenter`.
         pulse_direction_constraint : int, list of int, optional
             Sets a constraint on the direction of the fitted pulse. If 0, then no constraint on the
             pulse direction is set. If 1, then a positive pulse constraint is set for all fits.
@@ -712,13 +747,14 @@ class SetupRQ(object):
             lgcrun=lgcrun,
             lgcrun_smooth=lgcrun_smooth,
             nconstrain=nconstrain,
+            windowcenter=windowcenter,
             pulse_direction_constraint=pulse_direction_constraint,
         )
 
         self.do_ofamp_pileup = lgcrun
         self.do_ofamp_pileup_smooth = lgcrun_smooth
         self.ofamp_pileup_nconstrain = nconstrain
-
+        self.ofamp_pileup_windowcenter = windowcenter
         self.ofamp_pileup_pulse_constraint = pulse_direction_constraint
 
         self._check_of()
@@ -1278,69 +1314,107 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
                 amp_nodelay_smooth[jj], chi2_nodelay_smooth[jj] = OF_smooth.ofamp_nodelay()
 
             if setup.ofamp_nodelay_lowfreqchi2 and setup.do_chi2_lowfreq[chan_num]:
-                chi2low_nodelay[jj] = OF.chi2_lowfreq(amp_nodelay[jj], 0, 
-                                              fcutoff=setup.chi2_lowfreq_fcutoff[chan_num])
+                chi2low_nodelay[jj] = OF.chi2_lowfreq(
+                    amp_nodelay[jj],
+                    0,
+                    fcutoff=setup.chi2_lowfreq_fcutoff[chan_num],
+                )
 
             if setup.do_ofamp_unconstrained[chan_num]:
                 amp_noconstrain[jj], t0_noconstrain[jj], chi2_noconstrain[jj] = OF.ofamp_withdelay()
                 if setup.ofamp_unconstrained_pulse_constraint[chan_num]!=0:
                     amp_noconstrain_pcon[jj], t0_noconstrain_pcon[jj], chi2_noconstrain_pcon[jj] = OF.ofamp_withdelay(
-                                            pulse_direction_constraint=setup.ofamp_unconstrained_pulse_constraint[chan_num])
+                        pulse_direction_constraint=setup.ofamp_unconstrained_pulse_constraint[chan_num],
+                    )
 
             if setup.do_ofamp_unconstrained_smooth[chan_num]:
                 amp_noconstrain_smooth[jj], t0_noconstrain_smooth[jj], chi2_noconstrain_smooth[jj] = OF_smooth.ofamp_withdelay()
 
             if setup.ofamp_unconstrained_lowfreqchi2 and setup.do_chi2_lowfreq[chan_num]:
-                chi2low_unconstrain[jj] = OF.chi2_lowfreq(amp_noconstrain[jj], t0_noconstrain[jj], 
-                                                          fcutoff=setup.chi2_lowfreq_fcutoff[chan_num])
+                chi2low_unconstrain[jj] = OF.chi2_lowfreq(
+                    mp_noconstrain[jj],
+                    t0_noconstrain[jj],
+                    fcutoff=setup.chi2_lowfreq_fcutoff[chan_num],
+                )
                 if setup.ofamp_unconstrained_pulse_constraint[chan_num]!=0:
-                    chi2low_unconstrain_pcon[jj] = OF.chi2_lowfreq(amp_noconstrain_pcon[jj], t0_noconstrain_pcon[jj], 
-                                                                   fcutoff=setup.chi2_lowfreq_fcutoff[chan_num])
+                    chi2low_unconstrain_pcon[jj] = OF.chi2_lowfreq(
+                        amp_noconstrain_pcon[jj],
+                        t0_noconstrain_pcon[jj],
+                        fcutoff=setup.chi2_lowfreq_fcutoff[chan_num],
+                    )
 
             if setup.do_ofamp_constrained[chan_num]:
                 amp_constrain[jj], t0_constrain[jj], chi2_constrain[jj] = OF.ofamp_withdelay(
-                                                                          nconstrain=setup.ofamp_constrained_nconstrain[chan_num])
+                    nconstrain=setup.ofamp_constrained_nconstrain[chan_num],
+                    windowcenter=setup.ofamp_constrained_windowcenter[chan_num],
+                )
                 if setup.ofamp_constrained_pulse_constraint[chan_num]!=0:
                     amp_constrain_pcon[jj], t0_constrain_pcon[jj], chi2_constrain_pcon[jj] = OF.ofamp_withdelay(
-                                                                 nconstrain=setup.ofamp_constrained_nconstrain[chan_num],
-                                            pulse_direction_constraint=setup.ofamp_constrained_pulse_constraint[chan_num])
+                        nconstrain=setup.ofamp_constrained_nconstrain[chan_num],
+                        pulse_direction_constraint=setup.ofamp_constrained_pulse_constraint[chan_num],
+                        windowcenter=setup.ofamp_constrained_windowcenter[chan_num],
+                    )
 
             if setup.do_ofamp_constrained_smooth[chan_num]:
                 amp_constrain_smooth[jj], t0_constrain_smooth[jj], chi2_constrain_smooth[jj] = OF_smooth.ofamp_withdelay(
-                                                                          nconstrain=setup.ofamp_constrained_nconstrain[chan_num])
+                    nconstrain=setup.ofamp_constrained_nconstrain[chan_num],
+                    windowcenter=setup.ofamp_constrained_windowcenter[chan_num],
+                )
 
             if setup.ofamp_constrained_lowfreqchi2 and setup.do_chi2_lowfreq[chan_num]:
-                chi2low_constrain[jj] = OF.chi2_lowfreq(amp_constrain[jj], t0_constrain[jj], 
-                                                        fcutoff=setup.chi2_lowfreq_fcutoff[chan_num])
+                chi2low_constrain[jj] = OF.chi2_lowfreq(
+                    amp_constrain[jj],
+                    t0_constrain[jj],
+                    fcutoff=setup.chi2_lowfreq_fcutoff[chan_num],
+                )
                 if setup.ofamp_constrained_pulse_constraint[chan_num]!=0:
-                    chi2low_constrain_pcon[jj] = OF.chi2_lowfreq(amp_constrain_pcon[jj], t0_constrain_pcon[jj], 
-                                                                fcutoff=setup.chi2_lowfreq_fcutoff[chan_num])
+                    chi2low_constrain_pcon[jj] = OF.chi2_lowfreq(
+                        amp_constrain_pcon[jj],
+                        t0_constrain_pcon[jj],
+                        fcutoff=setup.chi2_lowfreq_fcutoff[chan_num],
+                    )
 
             if setup.do_ofamp_pileup[chan_num]:
-                amp_pileup[jj], t0_pileup[jj], chi2_pileup[jj] = OF.ofamp_pileup_iterative(amp_constrain[jj], t0_constrain[jj],
-                                                                   nconstrain=setup.ofamp_pileup_nconstrain[chan_num])
+                amp_pileup[jj], t0_pileup[jj], chi2_pileup[jj] = OF.ofamp_pileup_iterative(
+                    amp_constrain[jj],
+                    t0_constrain[jj],
+                    nconstrain=setup.ofamp_pileup_nconstrain[chan_num],
+                    windowcenter=setup.ofamp_pileup_windowcenter[chan_num],
+                )
                 if setup.ofamp_pileup_pulse_constraint[chan_num]!=0:
-                    amp_pileup_pcon[jj], t0_pileup_pcon[jj], chi2_pileup_pcon[jj] = OF.ofamp_pileup_iterative(amp_constrain[jj], 
-                                                                 t0_constrain[jj],
-                                                                 nconstrain=setup.ofamp_pileup_nconstrain[chan_num],
-                                            pulse_direction_constraint=setup.ofamp_pileup_pulse_constraint[chan_num])
+                    amp_pileup_pcon[jj], t0_pileup_pcon[jj], chi2_pileup_pcon[jj] = OF.ofamp_pileup_iterative(
+                        amp_constrain[jj],
+                        t0_constrain[jj],
+                        nconstrain=setup.ofamp_pileup_nconstrain[chan_num],
+                        pulse_direction_constraint=setup.ofamp_pileup_pulse_constraint[chan_num],
+                        windowcenter=setup.ofamp_pileup_windowcenter[chan_num],
+                    )
 
             if setup.do_ofamp_pileup_smooth[chan_num]:
                 amp_pileup_smooth[jj], t0_pileup_smooth[jj], chi2_pileup_smooth[jj] = OF_smooth.ofamp_pileup_iterative(
-                                                                   amp_constrain_smooth[jj], t0_constrain_smooth[jj],
-                                                                   nconstrain=setup.ofamp_pileup_nconstrain[chan_num])
+                    amp_constrain_smooth[jj],
+                    t0_constrain_smooth[jj],
+                    nconstrain=setup.ofamp_pileup_nconstrain[chan_num],
+                    windowcenter=setup.ofamp_pileup_windowcenter[chan_num],
+                )
 
             if setup.do_ofamp_baseline[chan_num]:
                 amp_baseline[jj], t0_baseline[jj], chi2_baseline[jj] = OF.ofamp_baseline(
-                                                                       nconstrain=setup.ofamp_baseline_nconstrain[chan_num])
+                    nconstrain=setup.ofamp_baseline_nconstrain[chan_num],
+                    windowcenter=setup.ofamp_baseline_windowcenter[chan_num],
+                )
                 if setup.ofamp_baseline_pulse_constraint[chan_num]!=0:
                     amp_baseline_pcon[jj], t0_baseline_pcon[jj], chi2_baseline_pcon[jj] = OF.ofamp_baseline(
-                                                                 nconstrain=setup.ofamp_baseline_nconstrain[chan_num],
-                                            pulse_direction_constraint=setup.ofamp_baseline_pulse_constraint[chan_num])
+                        nconstrain=setup.ofamp_baseline_nconstrain[chan_num],
+                        pulse_direction_constraint=setup.ofamp_baseline_pulse_constraint[chan_num],
+                        windowcenter=setup.ofamp_baseline_windowcenter[chan_num],
+                    )
 
             if setup.do_ofamp_baseline_smooth[chan_num]:
                 amp_baseline_smooth[jj], t0_baseline_smooth[jj], chi2_baseline_smooth[jj] = OF_smooth.ofamp_baseline(
-                                                                       nconstrain=setup.ofamp_baseline_nconstrain[chan_num])
+                    nconstrain=setup.ofamp_baseline_nconstrain[chan_num],
+                    windowcenter=setup.ofamp_baseline_windowcenter[chan_num],
+                )
 
             if setup.do_ofnonlin[chan_num]:
                 if setup.ofnonlin_positive_pulses[chan_num]:

--- a/rqpy/process/_process_rq.py
+++ b/rqpy/process/_process_rq.py
@@ -219,7 +219,7 @@ class SetupRQ(object):
         with a smoothed PSD. Useful in the case where the PSD for a channel has large spike(s) 
         in order to suppress echoes elsewhere in the trace. Each value in the list specifies this
         attribute for each channel.
-    shifted_fit : str
+    which_fit_shifted : str
         String specifying which fit that the time shift should be pulled from if the shifted
         optimum filter fit will be calculated. Should be "nodelay", "constrained", or "unconstrained",
         referring the the no delay OF, constrained OF, and unconstrained OF, respectively. Default
@@ -401,7 +401,7 @@ class SetupRQ(object):
 
         self.do_ofamp_shifted = [False]*self.nchan
         self.do_ofamp_shifted_smooth = [False]*self.nchan
-        self.which_fit = "constrained"
+        self.which_fit_shifted = "constrained"
         self.t0_shifted = None
         self.t0_shifted_smooth = None
 
@@ -1033,7 +1033,7 @@ class SetupRQ(object):
                 raise ValueError("""which_fit was set to 'nodelay', but that fit (using the smoothed PSD) 
                                  has been set to not be calculated""")
 
-        self.shifted_fit = which_fit
+        self.which_fit_shifted = which_fit
 
     def adjust_ofnonlin(self, lgcrun=True, positive_pulses=True):
         """
@@ -1273,11 +1273,11 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
     if any(setup.do_ofamp_shifted) and setup.trigger is not None:
         # do the shifted OF on each trace
         if chan_num==setup.trigger:
-            if setup.shifted_fit=="nodelay" and any(setup.do_ofamp_nodelay):
+            if setup.which_fit_shifted=="nodelay" and any(setup.do_ofamp_nodelay):
                 setup.t0_shifted = np.zeros(len(signal))
-            elif setup.shifted_fit=="constrained" and any(setup.do_ofamp_constrained):
+            elif setup.which_fit_shifted=="constrained" and any(setup.do_ofamp_constrained):
                 setup.t0_shifted = t0_constrain
-            elif setup.shifted_fit=="unconstrained" and any(setup.do_ofamp_unconstrained):
+            elif setup.which_fit_shifted=="unconstrained" and any(setup.do_ofamp_unconstrained):
                 setup.t0_shifted = t0_unconstrain
         elif setup.do_ofamp_shifted[chan_num]:
             amp_shifted = np.zeros(len(signal))
@@ -1287,11 +1287,11 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
         # do the shifted OF on each trace
         if chan_num==setup.trigger:
             if not setup.do_ofamp_shifted:
-                if setup.shifted_fit=="nodelay" and any(setup.do_ofamp_nodelay_smooth):
+                if setup.which_fit_shifted=="nodelay" and any(setup.do_ofamp_nodelay_smooth):
                     setup.t0_shifted_smooth = np.zeros(len(signal))
-                elif setup.shifted_fit=="constrained" and any(setup.do_ofamp_constrained_smooth):
+                elif setup.which_fit_shifted=="constrained" and any(setup.do_ofamp_constrained_smooth):
                     setup.t0_shifted_smooth = t0_constrain
-                elif setup.shifted_fit=="unconstrained" and any(setup.do_ofamp_unconstrained_smooth):
+                elif setup.which_fit_shifted=="unconstrained" and any(setup.do_ofamp_unconstrained_smooth):
                     setup.t0_shifted_smooth = t0_unconstrain
         elif setup.do_ofamp_shifted_smooth[chan_num]:
             amp_shifted_smooth = np.zeros(len(signal))

--- a/rqpy/process/_process_rq.py
+++ b/rqpy/process/_process_rq.py
@@ -1002,7 +1002,7 @@ class SetupRQ(object):
 
         self.do_ofamp_shifted = lgcrun
 
-        if self.do_ofamp_shifted:
+        if any(self.do_ofamp_shifted):
             if which_fit not in ["constrained", "unconstrained", "nodelay"]:
                 raise ValueError("which_fit should be set to 'constrained', 'unconstrained', or 'nodelay'")
 
@@ -1017,7 +1017,7 @@ class SetupRQ(object):
 
         self.do_ofamp_shifted_smooth = lgcrun_smooth
 
-        if self.do_ofamp_shifted_smooth:
+        if any(self.do_ofamp_shifted_smooth):
             if which_fit not in ["constrained", "unconstrained", "nodelay"]:
                 raise ValueError("which_fit should be set to 'constrained', 'unconstrained', or 'nodelay'")
 

--- a/rqpy/process/_process_rq.py
+++ b/rqpy/process/_process_rq.py
@@ -15,14 +15,14 @@ __all__ = ["SetupRQ", "rq"]
 class SetupRQ(object):
     """
     Class for setting up the calculation of RQs when processing data.
-    
+
     Attributes
     ----------
     templates : ndarray
         List of pulse templates corresponding to each channel. The pulse templates should
         be normalized.
     psds : ndarray
-        List of PSDs coresponding to each channel. Should be two-sided PSDs, with units of A^2/Hz.
+        List of PSDs corresponding to each channel. Should be two-sided PSDs, with units of A^2/Hz.
     fs : float
         The digitization rate of the data in Hz.
     summed_template : ndarray
@@ -402,11 +402,11 @@ class SetupRQ(object):
     def _check_of(self):
         """
         Helper function for checking if any of the optimum filters are going to be calculated.
-        
+
         """
-        
+
         do_optimumfilters = [False]*self.nchan
-        
+
         if any(self.do_ofamp_nodelay):
             do_optimumfilters = [ii or jj for ii, jj in zip(do_optimumfilters, self.do_ofamp_nodelay)]
         if any(self.do_ofamp_unconstrained):
@@ -421,11 +421,11 @@ class SetupRQ(object):
             do_optimumfilters = [ii or jj for ii, jj in zip(do_optimumfilters, self.do_chi2_lowfreq)]
         if any(self.do_ofamp_baseline):
             do_optimumfilters = [ii or jj for ii, jj in zip(do_optimumfilters, self.do_ofamp_baseline)]
-        
+
         self.do_optimumfilters = do_optimumfilters
-        
+
         do_optimumfilters_smooth = [False]*self.nchan
-            
+
         if any(self.do_ofamp_nodelay_smooth):
             do_optimumfilters_smooth = [ii or jj for ii, jj in zip(do_optimumfilters_smooth, self.do_ofamp_nodelay_smooth)]
         if any(self.do_ofamp_unconstrained_smooth):
@@ -438,88 +438,88 @@ class SetupRQ(object):
             do_optimumfilters_smooth = [ii or jj for ii, jj in zip(do_optimumfilters_smooth, self.do_chi2_nopulse_smooth)]
         if any(self.do_ofamp_baseline_smooth):
             do_optimumfilters_smooth = [ii or jj for ii, jj in zip(do_optimumfilters_smooth, self.do_ofamp_baseline_smooth)]
-            
+
         self.do_optimumfilters_smooth = do_optimumfilters_smooth
-        
+
     def _check_arg_length(self, **kwargs):
         """
         Helper function for checking if the inputted `**kwargs` are list type and if they have same
         length as the number of channels.
-        
+
         Parameters
         ----------
         **kwargs : Arbitrary keyword arguments
             The inputted keyword arguments to check list type and length.
-        
+
         Returns
         -------
         out : list
             The list of values for each inputted kwarg, in the
             order that they were inputted.
-            
+
         Raises
         ------
         ValueError
             A ValueError is raised if the length of one of the `**kwargs` is not equal
             to `self.chan`.
         ValueError
-            A ValueError is raised if the `**kwargs` pulse_direction_constraint is inputted and 
+            A ValueError is raised if the `**kwargs` pulse_direction_constraint is inputted and
             one of the values is not set to 1, 0, or -1.
-        
+
         """
-    
+
         for key, value in kwargs.items():
             if np.isscalar(value):
                 kwargs[key] = [value]*self.nchan
-                
+
             if key == "pulse_direction_constraint" and not all(x in [-1, 0, 1] for x in kwargs[key]):
                 raise ValueError(f"{key} should be set to 0, 1, or -1")
 
             if len(kwargs[key])!=self.nchan:
                 raise ValueError(f"The length of {key} is not equal to the number of channels")
-        
+
         out = list(kwargs.values())
-        
+
         if len(out)==1:
             out = out[0]
-        
+
         return out
 
     def adjust_calc(self, lgcchans=True, lgcsum=True):
         """
         Method for adjusting the calculation of RQs for each individual channel and the sum
         of the channels.
-        
+
         Parameters
         ----------
         lgcchans : bool, optional
-            Boolean flag for whether or not to calculate the RQs for each of the individual 
+            Boolean flag for whether or not to calculate the RQs for each of the individual
             channels. Default is True.
         lgcsum : bool, optional
             Boolean flag for whether or not calculate the RQs for the sum of the channels.
             Requires summed_template and summed_psd to be set when initializing the SetupRQ
             object. Default is True.
-            
+
         Raises
         ------
         ValueError
             A ValueError is raised if lgcsum is set to True when the SetupRQ Object was not
             initialized with summed_template or summed_psd.
-        
+
         """
-        
+
         self.calcchans = lgcchans
-        
+
         if (self.summed_template is None or self.summed_psd is None) and lgcsum:
             raise ValueError("SetupRQ was not initialized with summed_template or summed_psd, cannot calculate the summed RQs")
         else:
             self.calcsum = lgcsum
-        
+
     def adjust_ofamp_nodelay(self, lgcrun=True, lgcrun_smooth=False, calc_lowfreqchi2=False):
         """
         Method for adjusting the calculation of the optimum filter fit with no time
         shifting.
-        
+
         Parameters
         ----------
         lgcrun : bool, list of bool, optional
@@ -527,118 +527,122 @@ class SetupRQ(object):
             shifting should be calculated.
         lgcrun_smooth : bool, list of bool, optional
             Boolean flag for whether or not the optimum filter fit with no time
-            shifting should be calculated with a smoothed PSD. Useful in the case 
-            where the PSD for a channel has large spike(s) in order to suppress echoes 
+            shifting should be calculated with a smoothed PSD. Useful in the case
+            where the PSD for a channel has large spike(s) in order to suppress echoes
             elsewhere in the trace.
         calc_lowfreqchi2 : bool, optional
-            Boolean flag for whether or not the low frequency chi^2 of this fit 
+            Boolean flag for whether or not the low frequency chi^2 of this fit
             should be calculated. The low frequency chi^2 calculation should be adjusted
             using the adjust_chi2_lowfreq method.
-        
+
         """
-        
+
         lgcrun, lgcrun_smooth = self._check_arg_length(lgcrun=lgcrun, lgcrun_smooth=lgcrun_smooth)
-        
+
         self.do_ofamp_nodelay = lgcrun
         self.do_ofamp_nodelay_smooth = lgcrun_smooth
         self.ofamp_nodelay_lowfreqchi2 = calc_lowfreqchi2
-        
+
         self._check_of()
-        
+
     def adjust_ofamp_unconstrained(self, lgcrun=True, lgcrun_smooth=False, calc_lowfreqchi2=False, 
                                    pulse_direction_constraint=0):
         """
-        Method for adjusting the calculation of the optimum filter fit with unconstrained 
+        Method for adjusting the calculation of the optimum filter fit with unconstrained
         time shifting.
-        
+
         Parameters
         ----------
         lgcrun : bool, list of bool, optional
-            Boolean flag for whether or not the optimum filter fit with unconstrained 
+            Boolean flag for whether or not the optimum filter fit with unconstrained
             time shifting should be calculated.
         lgcrun_smooth : bool, list of bool, optional
             Boolean flag for whether or not the optimum filter fit with unconstrained time
-            shifting should be calculated with a smoothed PSD. Useful in the case 
-            where the PSD for a channel has large spike(s) in order to suppress echoes 
+            shifting should be calculated with a smoothed PSD. Useful in the case
+            where the PSD for a channel has large spike(s) in order to suppress echoes
             elsewhere in the trace.
         calc_lowfreqchi2 : bool, optional
-            Boolean flag for whether or not the low frequency chi^2 of this fit 
+            Boolean flag for whether or not the low frequency chi^2 of this fit
             should be calculated. The low frequency chi^2 calculation should be adjusted
             using the adjust_chi2_lowfreq method. Default is False.
         pulse_direction_constraint : int, list of int, optional
-            Sets a constraint on the direction of the fitted pulse. If 0, then no constraint on the 
-            pulse direction is set. If 1, then a positive pulse constraint is set for all fits. 
+            Sets a constraint on the direction of the fitted pulse. If 0, then no constraint on the
+            pulse direction is set. If 1, then a positive pulse constraint is set for all fits.
             If -1, then a negative pulse constraint is set for all fits. If any other value, then
             an ValueError will be raised.
-        
+
         """
-        
-        lgcrun, lgcrun_smooth, pulse_direction_constraint = self._check_arg_length(lgcrun=lgcrun,
-                                                                                   lgcrun_smooth=lgcrun_smooth,
-                                                            pulse_direction_constraint=pulse_direction_constraint)
-        
+
+        lgcrun, lgcrun_smooth, pulse_direction_constraint = self._check_arg_length(
+            lgcrun=lgcrun,
+            lgcrun_smooth=lgcrun_smooth,
+            pulse_direction_constraint=pulse_direction_constraint,
+        )
+
         self.do_ofamp_unconstrained = lgcrun
         self.do_ofamp_unconstrained_smooth = lgcrun_smooth
         self.ofamp_unconstrained_lowfreqchi2 = calc_lowfreqchi2
-        
+
         self.ofamp_unconstrained_pulse_constraint = pulse_direction_constraint
-        
+
         self._check_of()
-        
+
     def adjust_ofamp_constrained(self, lgcrun=True, lgcrun_smooth=False, calc_lowfreqchi2=True, 
                                  nconstrain=80, pulse_direction_constraint=0):
         """
         Method for adjusting the calculation of the optimum filter fit with constrained 
         time shifting.
-        
+
         Parameters
         ----------
         lgcrun : bool, list of bool, optional
-            Boolean flag for whether or not the optimum filter fit with constrained 
+            Boolean flag for whether or not the optimum filter fit with constrained
             time shifting should be calculated.
         lgcrun_smooth : bool, list of bool, optional
             Boolean flag for whether or not the optimum filter fit with constrained time
-            shifting should be calculated with a smoothed PSD. Useful in the case 
-            where the PSD for a channel has large spike(s) in order to suppress echoes 
+            shifting should be calculated with a smoothed PSD. Useful in the case
+            where the PSD for a channel has large spike(s) in order to suppress echoes
             elsewhere in the trace.
         calc_lowfreqchi2 : bool, optional
-            Boolean flag for whether or not the low frequency chi^2 of this fit 
+            Boolean flag for whether or not the low frequency chi^2 of this fit
             should be calculated. The low frequency chi^2 calculation should be adjusted
             using the adjust_chi2_lowfreq method. Default is True.
         nconstrain : int, list of int, optional
             The length of the window (in bins), centered on the middle of the trace, 
-            to constrain the possible time shift values to when doing the optimum filter 
-            fit with constrained time shifting. Can be set to a list of values, if the 
+            to constrain the possible time shift values to when doing the optimum filter
+            fit with constrained time shifting. Can be set to a list of values, if the
             constrain window should be different for each channel. The length of the list should
             be the same length as the number of channels.
         pulse_direction_constraint : int, list of int, optional
-            Sets a constraint on the direction of the fitted pulse. If 0, then no constraint on the 
-            pulse direction is set. If 1, then a positive pulse constraint is set for all fits. 
+            Sets a constraint on the direction of the fitted pulse. If 0, then no constraint on the
+            pulse direction is set. If 1, then a positive pulse constraint is set for all fits.
             If -1, then a negative pulse constraint is set for all fits. If any other value, then
             an ValueError will be raised.
-        
+
         """
-        
-        lgcrun, lgcrun_smooth, nconstrain, pulse_direction_constraint = self._check_arg_length(lgcrun=lgcrun,
-                                                                                               lgcrun_smooth=lgcrun_smooth,
-                                                                                               nconstrain=nconstrain, 
-                                                                        pulse_direction_constraint=pulse_direction_constraint)
-        
+
+        lgcrun, lgcrun_smooth, nconstrain, pulse_direction_constraint = self._check_arg_length(
+            lgcrun=lgcrun,
+            lgcrun_smooth=lgcrun_smooth,
+            nconstrain=nconstrain,
+            pulse_direction_constraint=pulse_direction_constraint,
+        )
+
         self.do_ofamp_constrained = lgcrun
         self.do_ofamp_constrained_smooth = lgcrun_smooth
         self.ofamp_constrained_lowfreqchi2 = calc_lowfreqchi2
         self.ofamp_constrained_nconstrain = nconstrain
-        
+
         self.ofamp_constrained_pulse_constraint = pulse_direction_constraint
-        
+
         self._check_of()
-        
+
     def adjust_ofamp_baseline(self, lgcrun=True, lgcrun_smooth=False, 
                               nconstrain=80, pulse_direction_constraint=0):
         """
         Method for adjusting the calculation of the optimum filter fit with fixed 
         baseline.
-        
+
         Parameters
         ----------
         lgcrun : bool, list of bool, optional
@@ -646,79 +650,83 @@ class SetupRQ(object):
             should be calculated.
         lgcrun_smooth : bool, list of bool, optional
             Boolean flag for whether or not the optimum filter fit with fixed baseline
-            should be calculated with a smoothed PSD. Useful in the case where the PSD for a 
+            should be calculated with a smoothed PSD. Useful in the case where the PSD for a
             channel has large spike(s) in order to suppress echoes elsewhere in the trace.
         nconstrain : int, list of int, optional
-            The length of the window (in bins), centered on the middle of the trace, 
-            to constrain the possible time shift values to when doing the optimum filter 
+            The length of the window (in bins), centered on the middle of the trace,
+            to constrain the possible time shift values to when doing the optimum filter
             fit with fixed baseline. Can be set to a list of values, if the 
             constrain window should be different for each channel. The length of the list should
             be the same length as the number of channels.
         pulse_direction_constraint : int, list of int, optional
-            Sets a constraint on the direction of the fitted pulse. If 0, then no constraint on the 
-            pulse direction is set. If 1, then a positive pulse constraint is set for all fits. 
+            Sets a constraint on the direction of the fitted pulse. If 0, then no constraint on the
+            pulse direction is set. If 1, then a positive pulse constraint is set for all fits.
             If -1, then a negative pulse constraint is set for all fits. If any other value, then
             an ValueError will be raised.
-        
+
         """
-        
-        lgcrun, lgcrun_smooth, nconstrain, pulse_direction_constraint = self._check_arg_length(lgcrun=lgcrun,
-                                                                                               lgcrun_smooth=lgcrun_smooth,
-                                                                                               nconstrain=nconstrain, 
-                                                                        pulse_direction_constraint=pulse_direction_constraint)
-        
+
+        lgcrun, lgcrun_smooth, nconstrain, pulse_direction_constraint = self._check_arg_length(
+            lgcrun=lgcrun,
+            lgcrun_smooth=lgcrun_smooth,
+            nconstrain=nconstrain,
+            pulse_direction_constraint=pulse_direction_constraint,
+        )
+
         self.do_ofamp_baseline = lgcrun
         self.do_ofamp_baseline_smooth = lgcrun_smooth
         self.ofamp_baseline_nconstrain = nconstrain
-        
+
         self.ofamp_baseline_pulse_constraint = pulse_direction_constraint
-        
+
         self._check_of()
-        
+
     def adjust_ofamp_pileup(self, lgcrun=True, lgcrun_smooth=False, 
                             nconstrain=80, pulse_direction_constraint=0):
         """
         Method for adjusting the calculation of the pileup optimum filter fit.
-        
+
         Parameters
         ----------
         lgcrun : bool, list of bool, optional
             Boolean flag for whether or not the pileup optimum filter fit should be calculated.
         lgcrun_smooth : bool, list of bool, optional
-            Boolean flag for whether or not the pileup optimum filter fit should be calculated 
-            with a smoothed PSD. Useful in the case where the PSD for a channel has large spike(s) 
+            Boolean flag for whether or not the pileup optimum filter fit should be calculated
+            with a smoothed PSD. Useful in the case where the PSD for a channel has large spike(s)
             in order to suppress echoes elsewhere in the trace.
         nconstrain : int, list of int, optional
-            The length of the window (in bins), centered on the middle of the trace, outside 
-            of which to constrain the possible time shift values to when searching for a 
-            pileup pulse using ofamp_pileup. Can be set to a list of values, if the constrain 
+            The length of the window (in bins), centered on the middle of the trace, outside
+            of which to constrain the possible time shift values to when searching for a
+            pileup pulse using ofamp_pileup. Can be set to a list of values, if the constrain
             window should be different for each channel. The length of the list should
             be the same length as the number of channels.
         pulse_direction_constraint : int, list of int, optional
-            Sets a constraint on the direction of the fitted pulse. If 0, then no constraint on the 
-            pulse direction is set. If 1, then a positive pulse constraint is set for all fits. 
+            Sets a constraint on the direction of the fitted pulse. If 0, then no constraint on the
+            pulse direction is set. If 1, then a positive pulse constraint is set for all fits.
             If -1, then a negative pulse constraint is set for all fits. If any other value, then
             an ValueError will be raised.
-        
+
         """
-        
-        lgcrun, lgcrun_smooth, nconstrain, pulse_direction_constraint = self._check_arg_length(lgcrun=lgcrun,
-                                                                                               lgcrun_smooth=lgcrun_smooth,
-                                                                                               nconstrain=nconstrain, 
-                                                                        pulse_direction_constraint=pulse_direction_constraint)
-        
+
+        lgcrun, lgcrun_smooth, nconstrain, pulse_direction_constraint = self._check_arg_length(
+            lgcrun=lgcrun,
+            lgcrun_smooth=lgcrun_smooth,
+            nconstrain=nconstrain,
+            pulse_direction_constraint=pulse_direction_constraint,
+        )
+
         self.do_ofamp_pileup = lgcrun
         self.do_ofamp_pileup_smooth = lgcrun_smooth
         self.ofamp_pileup_nconstrain = nconstrain
-        
+
         self.ofamp_pileup_pulse_constraint = pulse_direction_constraint
-        
+
         self._check_of()
-        
+
     def adjust_chi2_nopulse(self, lgcrun=True, lgcrun_smooth=False):
         """
         Method for adjusting the calculation of the no pulse chi^2.
-        
+
         Parameters
         ----------
         lgcrun : bool, list of bool, optional
@@ -727,20 +735,20 @@ class SetupRQ(object):
             Boolean flag for whether or not the chi^2 for no pulse should be calculated 
             with a smoothed PSD. Useful in the case where the PSD for a channel has large 
             spike(s) in order to suppress echoes elsewhere in the trace.
-        
+
         """
-        
+
         lgcrun, lgcrun_smooth = self._check_arg_length(lgcrun=lgcrun, lgcrun_smooth=lgcrun_smooth)
-        
+
         self.do_chi2_nopulse = lgcrun
         self.do_chi2_nopulse_smooth = lgcrun_smooth
-        
+
         self._check_of()
-        
+
     def adjust_chi2_lowfreq(self, lgcrun=True, fcutoff=10000):
         """
         Method for adjusting the calculation of the low frequency chi^2.
-        
+
         Parameters
         ----------
         lgcrun : bool, list of bool, optional
@@ -751,20 +759,20 @@ class SetupRQ(object):
             Can be set to a list of values, if the frequency cutoff should be different for 
             each channel. The length of the list should be the same length as the number 
             of channels.
-            
+
         """
-        
+
         lgcrun, fcutoff = self._check_arg_length(lgcrun=lgcrun, fcutoff=fcutoff)
-            
+
         self.do_chi2_lowfreq = lgcrun
         self.chi2_lowfreq_fcutoff = fcutoff
-        
+
         self._check_of()
-        
+
     def adjust_baseline(self, lgcrun=True, indbasepre=None):
         """
         Method for adjusting the calculation of the DC baseline.
-        
+
         Parameters
         ----------
         lgcrun : bool, list of bool, optional
@@ -776,21 +784,21 @@ class SetupRQ(object):
             Can be set to a list of values, if indbasepre should be different for each channel. 
             The length of the list should be the same length as the number of channels. Default
             is one-third of the trace length.
-            
+
         """
-        
+
         if indbasepre is None:
             indbasepre = len(self.templates[0])//3
-        
+
         lgcrun, indbasepre = self._check_arg_length(lgcrun=lgcrun, indbasepre=indbasepre)
-            
+
         self.do_baseline = lgcrun
         self.baseline_indbasepre = indbasepre
-        
+
     def adjust_integral(self, lgcrun=True, indstart=None, indstop=None, indbasepre=None, indbasepost=None):
         """
         Method for adjusting the calculation of the integral.
-        
+
         Parameters
         ----------
         lgcrun : bool, list of bool, optional
@@ -815,7 +823,7 @@ class SetupRQ(object):
             with indbasepre to create the best estimate of the integral.  Can be set to a list of values,
             if indbasepost should be different for each channel. The length of the list should be the same
             length as the number of channels. Default is the two-thirds index of the trace length.
-            
+
         """
 
         if indstart is None:
@@ -841,7 +849,7 @@ class SetupRQ(object):
     def adjust_energy_absorbed(self, ioffset, qetbias, rload, rsh, lgcrun=True, indstart=None, indstop=None):
         """
         Method for calculating the energy absorbed by the TES, in the limit of infinite loop gain.
-        
+
         Parameters
         ----------
         ioffset : float, list of float
@@ -863,36 +871,38 @@ class SetupRQ(object):
         indstop : int, list of int, optional
             The index at which the integral should be calculated up to in order to reduce noise by 
             truncating the rest of the trace. Default is two-thirds of the trace length.
-        
+
         """
-        
+
         if indstart is None:
             indstart = len(self.templates[0])//3
-            
+
         if indstop is None:
             indstop = 2*len(self.templates[0])//3
         
-        lgcrun, ioffset, qetbias, rload, rsh, indstart, indstop = self._check_arg_length(lgcrun=lgcrun, 
-                                                                                         ioffset=ioffset, 
-                                                                                         qetbias=qetbias,
-                                                                                         rload=rload,
-                                                                                         rsh=rsh,
-                                                                                         indstart=indstart,
-                                                                                         indstop=indstop)
-        
+        lgcrun, ioffset, qetbias, rload, rsh, indstart, indstop = self._check_arg_length(
+            lgcrun=lgcrun,
+            ioffset=ioffset,
+            qetbias=qetbias,
+            rload=rload,
+            rsh=rsh,
+            indstart=indstart,
+            indstop=indstop,
+        )
+
         self.do_energy_absorbed = lgcrun
-        
+
         self.ioffset = ioffset
         self.qetbias = qetbias
         self.rload = rload
         self.rsh = rsh
         self.indstart_energy_absorbed = indstart
         self.indstop_energy_absorbed = indstop
-        
+
     def adjust_maxmin(self, lgcrun=True, use_min=False, indstart=None, indstop=None):
         """
         Method for adjusting the calculation of the range of a trace.
-        
+
         Parameters
         ----------
         lgcrun : bool, list of bool, optional
@@ -906,27 +916,31 @@ class SetupRQ(object):
         indstop : int, list of int, optional
             The end index for the range of values that that maxmin should be calculated over. Default is 
             None, which sets the end index to the end of the trace.
-            
+
         """
-        
+
         if indstart is None:
             indstart = 0
-        
+
         if indstop is None:
             indstop = len(self.templates[0])
-            
-        lgcrun, use_min, indstart, indstop = self._check_arg_length(lgcrun=lgcrun, use_min=use_min, 
-                                                                    indstart=indstart, indstop=indstop)
-        
+
+        lgcrun, use_min, indstart, indstop = self._check_arg_length(
+            lgcrun=lgcrun,
+            use_min=use_min,
+            indstart=indstart,
+            indstop=indstop,
+        )
+
         self.do_maxmin = lgcrun
         self.use_min = use_min
         self.indstart_maxmin = indstart
         self.indstop_maxmin = indstop
-        
+
     def adjust_ofamp_shifted(self, lgcrun=True, lgcrun_smooth=False, which_fit="constrained"):
         """
         Method for adjusting the calculation of the shifted optimum filter fit.
-        
+
         Parameters
         ----------
         lgcrun : bool, optional
@@ -941,13 +955,13 @@ class SetupRQ(object):
             optimum filter fit will be calculated. Should be "nodelay", "constrained", or "unconstrained",
             referring the the no delay OF, constrained OF, and unconstrained OF, respectively. Default
             is "constrained".
-            
+
         """
-        
+
         lgcrun, lgcrun_smooth = self._check_arg_length(lgcrun=lgcrun, lgcrun_smooth=lgcrun_smooth)
-        
+
         self.do_ofamp_shifted = lgcrun
-        
+
         if self.do_ofamp_shifted:
             if which_fit not in ["constrained", "unconstrained", "nodelay"]:
                 raise ValueError("which_fit should be set to 'constrained', 'unconstrained', or 'nodelay'")
@@ -960,9 +974,9 @@ class SetupRQ(object):
 
             if which_fit == "nodelay" and not self.do_ofamp_nodelay:
                 raise ValueError("which_fit was set to 'nodelay', but that fit has been set to not be calculated")
-                
+
         self.do_ofamp_shifted_smooth = lgcrun_smooth
-        
+
         if self.do_ofamp_shifted_smooth:
             if which_fit not in ["constrained", "unconstrained", "nodelay"]:
                 raise ValueError("which_fit should be set to 'constrained', 'unconstrained', or 'nodelay'")
@@ -978,14 +992,14 @@ class SetupRQ(object):
             if which_fit == "nodelay" and not self.do_ofamp_nodelay_smooth:
                 raise ValueError("""which_fit was set to 'nodelay', but that fit (using the smoothed PSD) 
                                  has been set to not be calculated""")
-            
+
         self.shifted_fit = which_fit
-        
+
     def adjust_ofnonlin(self, lgcrun=True, positive_pulses=True):
         """
         Method for adjusting the calculation of the nonlinear optimum filter fit with rise and 
         fall time floating.
-        
+
         Parameters
         ----------
         lgcrun : bool, list of bool, optional
@@ -993,19 +1007,18 @@ class SetupRQ(object):
         positive_pulses : bool, list of bool, optional
             If True, then the pulses are assumed to be in the positive direction. If False, then the 
             pulses are assumed to be in the negative direction. Default is True.
-        
+
         """
-        
+
         lgcrun, positive_pulses = self._check_arg_length(lgcrun=lgcrun, positive_pulses=positive_pulses)
-        
+
         if any(lgcrun):
             warnings.warn("The nonlinear OF should only be run on a cluster due to the slow computation speed.")
-        
+
         self.do_ofnonlin = lgcrun
         self.ofnonlin_positive_pulses = positive_pulses
-        
-    def adjust_trigsim(self, trigger_template, trigger_psd, threshold,
-                       k=12, fir_bits_out=32, fir_discard_msbs=4):
+
+    def adjust_trigsim(self, trigger_template, trigger_psd, k=12, fir_bits_out=32, fir_discard_msbs=4):
         """
         Method for setting up the use of the trigger simulation for `mid.gz` files.
 
@@ -1017,9 +1030,6 @@ class SetupRQ(object):
         trigger_psd : ndarray
             The input power spectral density to use for the FIR filter. Should be in
             units of ADC bins.
-        threshold : float
-            The threshold in the arbitrary units of the FIR filter to use for detection of pulses.
-            Should be a known quantity before attempting to use the trigger simulation.
         k : int, optional
             The bin number to start the FIR filter at. Since the filter downsamples the data
             by a factor of 16, the starting bin has a small effect on the calculated amplitude.
@@ -1053,15 +1063,18 @@ class SetupRQ(object):
         self.do_trigsim = lgcrun
         self.trigsim_k = k
 
-        self.TS = rp.sim.TrigSim(trigger_psd, trigger_template, self.fs,
-                                 fir_bits_out=fir_bits_out, fir_discard_msbs=fir_discard_msbs)
-        self.TS.set_threshold(threshold)
-
+        self.TS = rp.sim.TrigSim(
+            trigger_psd,
+            trigger_template,
+            self.fs,
+            fir_bits_out=fir_bits_out,
+            fir_discard_msbs=fir_discard_msbs,
+        )
 
 def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, chan_num, det):
     """
     Helper function for calculating RQs for an array of traces corresponding to a single channel.
-    
+
     Parameters
     ----------
     signal : ndarray
@@ -1072,10 +1085,10 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
     psd : ndarray
         The two-sided psd that will be used to describe the noise in the signal (in Amps^2/Hz)
     setup : SetupRQ
-        A SetupRQ class object. This object defines all of the different RQs that should be calculated 
+        A SetupRQ class object. This object defines all of the different RQs that should be calculated
         and specifies relevant parameters.
     readout_inds : ndarray of bool
-        Boolean mask that specifies which traces should be used to calculate the RQs. RQs for the 
+        Boolean mask that specifies which traces should be used to calculate the RQs. RQs for the
         excluded traces are set to -999999.0. 
     chan : str
         Name of the channel that is being processed.
@@ -1083,18 +1096,18 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
         The corresponding number for the channel being processed.
     det : str
         Name of the detector corresponding to the channel that is being processed.
-    
+
     Returns
     -------
     rq_dict : dict
         A dictionary containing all of the RQs that were calculated (as specified by the setup object).
-    
+
     """
-    
+
     rq_dict = {}
-    
+
     fs = setup.fs
-    
+
     if setup.do_baseline[chan_num]:
         baseline = np.mean(signal[:, :setup.baseline_indbasepre[chan_num]], axis=-1)
         rq_dict[f'baseline_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
@@ -1131,7 +1144,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
                                                        fs=fs)
         rq_dict[f'energy_absorbed_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'energy_absorbed_{chan}{det}'][readout_inds] = energy_absorbed
-        
+
     if setup.do_maxmin[chan_num]:
         if setup.use_min[chan_num]:
             maxmin = np.amin(signal[:, setup.indstart_maxmin[chan_num]:setup.indstop_maxmin[chan_num]], axis=-1)
@@ -1139,20 +1152,20 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
             maxmin = np.amax(signal[:, setup.indstart_maxmin[chan_num]:setup.indstop_maxmin[chan_num]], axis=-1)
         rq_dict[f'maxmin_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'maxmin_{chan}{det}'][readout_inds] = maxmin
-    
+
     # initialize variables for the various OFs
     if setup.do_chi2_nopulse[chan_num]:
         chi0 = np.zeros(len(signal))
     if setup.do_chi2_nopulse_smooth[chan_num]:
         chi0_smooth = np.zeros(len(signal))
-    
+
     if setup.do_ofamp_nodelay[chan_num]:
         amp_nodelay = np.zeros(len(signal))
         chi2_nodelay = np.zeros(len(signal))
     if setup.do_ofamp_nodelay_smooth[chan_num]:
         amp_nodelay_smooth = np.zeros(len(signal))
         chi2_nodelay_smooth = np.zeros(len(signal))
-    
+
     if setup.do_ofamp_unconstrained[chan_num]:
         amp_noconstrain = np.zeros(len(signal))
         t0_noconstrain = np.zeros(len(signal))
@@ -1165,7 +1178,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
         amp_noconstrain_smooth = np.zeros(len(signal))
         t0_noconstrain_smooth = np.zeros(len(signal))
         chi2_noconstrain_smooth = np.zeros(len(signal))
-    
+
     if setup.do_ofamp_constrained[chan_num]:
         amp_constrain = np.zeros(len(signal))
         t0_constrain = np.zeros(len(signal))
@@ -1178,7 +1191,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
         amp_constrain_smooth = np.zeros(len(signal))
         t0_constrain_smooth = np.zeros(len(signal))
         chi2_constrain_smooth = np.zeros(len(signal))
-    
+
     if setup.do_ofamp_pileup[chan_num]:
         amp_pileup = np.zeros(len(signal))
         t0_pileup = np.zeros(len(signal))
@@ -1191,7 +1204,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
         amp_pileup_smooth = np.zeros(len(signal))
         t0_pileup_smooth = np.zeros(len(signal))
         chi2_pileup_smooth = np.zeros(len(signal))
-    
+
     if setup.do_ofamp_baseline[chan_num]:
         amp_baseline = np.zeros(len(signal))
         t0_baseline = np.zeros(len(signal))
@@ -1204,7 +1217,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
         amp_baseline_smooth = np.zeros(len(signal))
         t0_baseline_smooth = np.zeros(len(signal))
         chi2_baseline_smooth = np.zeros(len(signal))
-        
+
     if setup.do_chi2_lowfreq[chan_num]:
         if setup.ofamp_nodelay_lowfreqchi2:
             chi2low_nodelay = np.zeros(len(signal))
@@ -1216,7 +1229,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
             chi2low_constrain = np.zeros(len(signal))
             if setup.ofamp_constrained_pulse_constraint[chan_num]!=0:
                 chi2low_constrain_pcon = np.zeros(len(signal))
-    
+
     if setup.do_ofnonlin[chan_num]:
         amp_nonlin = np.zeros(len(signal))
         amp_nonlin_err = np.zeros(len(signal))
@@ -1228,11 +1241,11 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
         t0_nonlin_err = np.zeros(len(signal))
         chi2_nonlin = np.zeros(len(signal))
         success_nonlin = np.zeros(len(signal))
-    
+
     if setup.do_trigsim[chan_num] and setup.trigger == chan_num:
         triggeramp_sim = np.zeros(len(signal))
         triggertime_sim = np.zeros(len(signal))
-    
+
     if any(readout_inds):
         # run the OF class for each trace
         if setup.do_optimumfilters[chan_num]:
@@ -1355,7 +1368,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
                 res_trigsim = setup.TS.trigger(setup.signal_full[jj, chan_num], k=setup.trigsim_k)
                 triggeramp_sim[jj] = res_trigsim[0]
                 triggertime_sim[jj] = res_trigsim[1]
-    
+
     # save variables to dict
     if setup.do_chi2_nopulse[chan_num]:
         rq_dict[f'chi2_nopulse_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
@@ -1363,7 +1376,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
     if setup.do_chi2_nopulse_smooth[chan_num]:
         rq_dict[f'chi2_nopulse_smooth_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'chi2_nopulse_smooth_{chan}{det}'][readout_inds] = chi0_smooth
-    
+
     if setup.do_ofamp_nodelay[chan_num]:
         rq_dict[f'ofamp_nodelay_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'ofamp_nodelay_{chan}{det}'][readout_inds] = amp_nodelay
@@ -1374,7 +1387,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
         rq_dict[f'ofamp_nodelay_smooth_{chan}{det}'][readout_inds] = amp_nodelay_smooth
         rq_dict[f'chi2_nodelay_smooth_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'chi2_nodelay_smooth_{chan}{det}'][readout_inds] = chi2_nodelay_smooth
-    
+
     if setup.do_ofamp_unconstrained[chan_num]:
         rq_dict[f'ofamp_unconstrain_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'ofamp_unconstrain_{chan}{det}'][readout_inds] = amp_noconstrain
@@ -1396,7 +1409,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
         rq_dict[f't0_unconstrain_smooth_{chan}{det}'][readout_inds] = t0_noconstrain_smooth
         rq_dict[f'chi2_unconstrain_smooth_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'chi2_unconstrain_smooth_{chan}{det}'][readout_inds] = chi2_noconstrain_smooth
-    
+
     if setup.do_ofamp_constrained[chan_num]:
         rq_dict[f'ofamp_constrain_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'ofamp_constrain_{chan}{det}'][readout_inds] = amp_constrain
@@ -1418,26 +1431,26 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
         rq_dict[f't0_constrain_smooth_{chan}{det}'][readout_inds] = t0_constrain_smooth
         rq_dict[f'chi2_constrain_smooth_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'chi2_constrain_smooth_{chan}{det}'][readout_inds] = chi2_constrain_smooth
-        
+
     if setup.do_chi2_lowfreq[chan_num]:
         if setup.ofamp_nodelay_lowfreqchi2:
             rq_dict[f'chi2lowfreq_nodelay_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
             rq_dict[f'chi2lowfreq_nodelay_{chan}{det}'][readout_inds] = chi2low_nodelay
-        
+
         if setup.ofamp_unconstrained_lowfreqchi2:
             rq_dict[f'chi2lowfreq_unconstrain_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
             rq_dict[f'chi2lowfreq_unconstrain_{chan}{det}'][readout_inds] = chi2low_unconstrain
             if setup.ofamp_unconstrained_pulse_constraint[chan_num]!=0:
                 rq_dict[f'chi2lowfreq_unconstrain_pcon_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
                 rq_dict[f'chi2lowfreq_unconstrain_pcon_{chan}{det}'][readout_inds] = chi2low_unconstrain_pcon
-        
+
         if setup.ofamp_constrained_lowfreqchi2:
             rq_dict[f'chi2lowfreq_constrain_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
             rq_dict[f'chi2lowfreq_constrain_{chan}{det}'][readout_inds] = chi2low_constrain
             if setup.ofamp_constrained_pulse_constraint[chan_num]!=0:
                 rq_dict[f'chi2lowfreq_constrain_pcon_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
                 rq_dict[f'chi2lowfreq_constrain_pcon_{chan}{det}'][readout_inds] = chi2low_constrain_pcon
-    
+
     if setup.do_ofamp_pileup[chan_num]:
         rq_dict[f'ofamp_pileup_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'ofamp_pileup_{chan}{det}'][readout_inds] = amp_pileup
@@ -1459,7 +1472,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
         rq_dict[f't0_pileup_smooth_{chan}{det}'][readout_inds] = t0_pileup_smooth
         rq_dict[f'chi2_pileup_smooth_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'chi2_pileup_smooth_{chan}{det}'][readout_inds] = chi2_pileup_smooth
-        
+
     if setup.do_ofamp_baseline[chan_num]:
         rq_dict[f'ofamp_baseline_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'ofamp_baseline_{chan}{det}'][readout_inds] = amp_baseline
@@ -1481,7 +1494,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
         rq_dict[f't0_baseline_smooth_{chan}{det}'][readout_inds] = t0_baseline_smooth
         rq_dict[f'chi2_baseline_smooth_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'chi2_baseline_smooth_{chan}{det}'][readout_inds] = chi2_baseline_smooth
-    
+
     if setup.do_ofnonlin[chan_num]:
         rq_dict[f'ofamp_nlin_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'ofamp_nlin_{chan}{det}'][readout_inds] = amp_nonlin
@@ -1503,13 +1516,13 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
         rq_dict[f'chi2_nlin_{chan}{det}'][readout_inds] = chi2_nonlin
         rq_dict[f'success_nlin_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'success_nlin_{chan}{det}'][readout_inds] = success_nonlin
-    
+
     if setup.do_trigsim[chan_num] and setup.trigger == chan_num:
         rq_dict[f'triggeramp_sim_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'triggeramp_sim_{chan}{det}'][readout_inds] = triggeramp_sim
         rq_dict[f'triggertime_sim_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
         rq_dict[f'triggertime_sim_{chan}{det}'][readout_inds] = triggertime_sim
-    
+
     if any(setup.do_ofamp_shifted) and setup.trigger is not None:
         # do the shifted OF on each trace
         if chan_num==setup.trigger:
@@ -1533,7 +1546,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
             rq_dict[f't0_shifted_{chan}{det}'][readout_inds] = setup.t0_shifted
             rq_dict[f'chi2_shifted_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
             rq_dict[f'chi2_shifted_{chan}{det}'][readout_inds] = chi2_shifted
-            
+
     if any(setup.do_ofamp_shifted_smooth) and setup.trigger is not None:
         # do the shifted OF on each trace
         if chan_num==setup.trigger:
@@ -1558,13 +1571,13 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
             rq_dict[f't0_shifted_smooth_{chan}{det}'][readout_inds] = setup.t0_shifted
             rq_dict[f'chi2_shifted_smooth_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
             rq_dict[f'chi2_shifted_smooth_{chan}{det}'][readout_inds] = chi2_shifted_smooth
-    
+
     return rq_dict
-    
+
 def _calc_rq(traces, channels, det, setup, readout_inds=None):
     """
     Helper function for calculating RQs for arrays of traces.
-    
+
     Parameters
     ----------
     traces : ndarray
@@ -1580,37 +1593,37 @@ def _calc_rq(traces, channels, det, setup, readout_inds=None):
     readout_inds : ndarray of bool, optional
         Boolean mask that specifies which traces should be used to calculate the RQs. RQs for the 
         excluded traces are set to -999999.0. 
-    
+
     Returns
     -------
     rq_dict : dict
         A dictionary containing all of the RQs that were calculated (as specified by the setup object).
-    
+
     """
-    
+
     if readout_inds is None:
         readout_inds = np.ones(len(traces), dtype=bool)
-    
+
     rq_dict = {}
-    
+
     if setup.calcchans:
         vals = list(enumerate(zip(channels, det)))
-        
+
         if setup.do_ofamp_shifted and setup.trigger is not None:
             # change order so that trigger is processed to be able get the shifted times
             # to be able to shift the non-trigger channels to the right time
             vals[setup.trigger], vals[0] = vals[0], vals[setup.trigger]
-        
+
         for ii, (chan, d) in vals:
             signal = traces[readout_inds, ii, setup.indstart:setup.indstop]
-            
+
             template = setup.templates[ii]
             psd = setup.psds[ii]
 
             chan_dict = _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ii, d)
-            
+
             rq_dict.update(chan_dict)
-            
+
     if setup.calcsum:
         signal = traces[readout_inds, :, setup.indstart:setup.indstop].sum(axis=1)
         template = setup.summed_template
@@ -1620,13 +1633,13 @@ def _calc_rq(traces, channels, det, setup, readout_inds=None):
         sum_dict = _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, 0, "")
 
         rq_dict.update(sum_dict)
-    
+
     return rq_dict
 
 def _rq(file, channels, det, setup, convtoamps, savepath, lgcsavedumps, filetype):
     """
     Helper function for processing raw data to calculate RQs for single files.
-    
+
     Parameters
     ----------
     file : str
@@ -1649,50 +1662,50 @@ def _rq(file, channels, det, setup, convtoamps, savepath, lgcsavedumps, filetype
     filetype : str
         The string that corresponds to the file type that will be opened. Supports two 
         types -"mid.gz" and "npz".
-    
+
     Returns
     -------
     rq_df : pandas.DataFrame
         A pandas DataFrame object that contains all of the RQs for the dataset specified.
-    
+
     """
-    
+
     if filetype == "mid.gz" and not HAS_SCDMSPYTOOLS:
         raise ImportError("Cannot use filetype mid.gz because scdmsPyTools is not installed.")
-    
+
     if filetype == "npz" and any(setup.do_trigsim):
         raise ValueError("setup.do_trigsim was set to True for filetype npz. " +\
                          "The trigger simulation is only meant for filetype mid.gz")
-    
+
     if filetype == "mid.gz":
         seriesnum = file.split('/')[-2]
         dump = file.split('/')[-1].split('_')[-1].split('.')[0]
     elif filetype == "npz":
         seriesnum = file.split('/')[-1].split('.')[0]
         dump = f"{int(seriesnum.split('_')[-1]):04d}"
-        
+
     print(f"On Series: {seriesnum},  dump: {dump}")
-    
+
     if isinstance(channels, str):
         channels = [channels]
-        
+
     if isinstance(det, str):
         det = [det]*len(channels)
-        
+
     if len(det)!=len(channels):
         raise ValueError("channels and det should have the same length")
-    
+
     if filetype == "mid.gz":
         # note that we don't input convtoamps here, this is in case the trigger simulation will be run
         traces_unscaled, info_dict = io.get_traces_midgz([file], channels=channels, det=det, convtoamps=1,
                                                          lgcskip_empty=False, lgcreturndict=True)
     elif filetype == "npz":
         traces, info_dict = io.get_traces_npz([file])
-    
+
     data = {}
-    
+
     data.update(info_dict)
-    
+
     if filetype == "mid.gz":
         readout_inds = []
         for d in set(det):
@@ -1711,13 +1724,13 @@ def _rq(file, channels, det, setup, convtoamps, savepath, lgcsavedumps, filetype
         traces = traces_unscaled * convtoamps_arr
     elif filetype == "npz":
         readout_inds = None
-    
+
     rq_dict = _calc_rq(traces, channels, det, setup, readout_inds=readout_inds)
-    
+
     data.update(rq_dict)
-    
+
     rq_df = pd.DataFrame.from_dict(data)
-    
+
     if lgcsavedumps:
         rq_df.to_pickle(f'{savepath}rq_df_{seriesnum}_d{dump}.pkl')   
 
@@ -1727,7 +1740,7 @@ def _rq(file, channels, det, setup, convtoamps, savepath, lgcsavedumps, filetype
 def rq(filelist, channels, setup, det="Z1", savepath='', lgcsavedumps=False, nprocess=1, filetype="mid.gz"):
     """
     Function for processing raw data to calculate RQs. Supports multiprocessing.
-    
+
     Parameters
     ----------
     filelist : list
@@ -1754,31 +1767,31 @@ def rq(filelist, channels, setup, det="Z1", savepath='', lgcsavedumps=False, npr
     filetype : str, optional
         The string that corresponds to the file type that will be opened. Supports two 
         types -"mid.gz" and "npz". "mid.gz" is the default.
-    
+
     Returns
     -------
     rq_df : pandas.DataFrame
         A pandas DataFrame object that contains all of the RQs for each dataset in filelist.
-    
+
     """
-    
+
     if filetype == "mid.gz" and not HAS_SCDMSPYTOOLS:
         raise ImportError("Cannot use filetype mid.gz because scdmsPyTools is not installed.")
-    
+
     if isinstance(filelist, str):
         filelist = [filelist]
-        
+
     if isinstance(channels, str):
         channels = [channels]
-        
+
     if isinstance(det, str):
         det = [det]*len(channels)
-        
+
     if len(det)!=len(channels):
         raise ValueError("channels and det should have the same length")
-    
+
     folder = os.path.split(filelist[0])[0]
-    
+
     if filetype == "mid.gz":
         convtoamps = []
         for ch, d in zip(channels, det):
@@ -1797,8 +1810,8 @@ def rq(filelist, channels, setup, det="Z1", savepath='', lgcsavedumps=False, npr
                                         repeat(filetype)))
         pool.close()
         pool.join()
-    
+
     rq_df = pd.concat([df for df in results], ignore_index = True)
-    
+
     return rq_df
 

--- a/rqpy/process/_process_rq.py
+++ b/rqpy/process/_process_rq.py
@@ -961,7 +961,7 @@ class SetupRQ(object):
 
         if indstop is None:
             indstop = 2*len(self.templates[0])//3
-        
+
         lgcrun, ioffset, qetbias, rload, rsh, indstart, indstop = self._check_arg_length(
             lgcrun=lgcrun,
             ioffset=ioffset,
@@ -1249,17 +1249,17 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
         chi2_nodelay_smooth = np.zeros(len(signal))
 
     if setup.do_ofamp_unconstrained[chan_num]:
-        amp_noconstrain = np.zeros(len(signal))
-        t0_noconstrain = np.zeros(len(signal))
-        chi2_noconstrain = np.zeros(len(signal))
+        amp_unconstrain = np.zeros(len(signal))
+        t0_unconstrain = np.zeros(len(signal))
+        chi2_unconstrain = np.zeros(len(signal))
         if setup.ofamp_unconstrained_pulse_constraint[chan_num]!=0:
-            amp_noconstrain_pcon = np.zeros(len(signal))
-            t0_noconstrain_pcon  = np.zeros(len(signal))
-            chi2_noconstrain_pcon  = np.zeros(len(signal))
+            amp_unconstrain_pcon = np.zeros(len(signal))
+            t0_unconstrain_pcon  = np.zeros(len(signal))
+            chi2_unconstrain_pcon  = np.zeros(len(signal))
     if setup.do_ofamp_unconstrained_smooth[chan_num]:
-        amp_noconstrain_smooth = np.zeros(len(signal))
-        t0_noconstrain_smooth = np.zeros(len(signal))
-        chi2_noconstrain_smooth = np.zeros(len(signal))
+        amp_unconstrain_smooth = np.zeros(len(signal))
+        t0_unconstrain_smooth = np.zeros(len(signal))
+        chi2_unconstrain_smooth = np.zeros(len(signal))
 
     if setup.do_ofamp_constrained[chan_num]:
         amp_constrain = np.zeros(len(signal))
@@ -1375,25 +1375,25 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
                 )
 
             if setup.do_ofamp_unconstrained[chan_num]:
-                amp_noconstrain[jj], t0_noconstrain[jj], chi2_noconstrain[jj] = OF.ofamp_withdelay()
+                amp_unconstrain[jj], t0_unconstrain[jj], chi2_unconstrain[jj] = OF.ofamp_withdelay()
                 if setup.ofamp_unconstrained_pulse_constraint[chan_num]!=0:
-                    amp_noconstrain_pcon[jj], t0_noconstrain_pcon[jj], chi2_noconstrain_pcon[jj] = OF.ofamp_withdelay(
+                    amp_unconstrain_pcon[jj], t0_unconstrain_pcon[jj], chi2_unconstrain_pcon[jj] = OF.ofamp_withdelay(
                         pulse_direction_constraint=setup.ofamp_unconstrained_pulse_constraint[chan_num],
                     )
 
             if setup.do_ofamp_unconstrained_smooth[chan_num]:
-                amp_noconstrain_smooth[jj], t0_noconstrain_smooth[jj], chi2_noconstrain_smooth[jj] = OF_smooth.ofamp_withdelay()
+                amp_unconstrain_smooth[jj], t0_unconstrain_smooth[jj], chi2_unconstrain_smooth[jj] = OF_smooth.ofamp_withdelay()
 
             if setup.ofamp_unconstrained_lowfreqchi2 and setup.do_chi2_lowfreq[chan_num]:
                 chi2low_unconstrain[jj] = OF.chi2_lowfreq(
-                    amp_noconstrain[jj],
-                    t0_noconstrain[jj],
+                    amp_unconstrain[jj],
+                    t0_unconstrain[jj],
                     fcutoff=setup.chi2_lowfreq_fcutoff[chan_num],
                 )
                 if setup.ofamp_unconstrained_pulse_constraint[chan_num]!=0:
                     chi2low_unconstrain_pcon[jj] = OF.chi2_lowfreq(
-                        amp_noconstrain_pcon[jj],
-                        t0_noconstrain_pcon[jj],
+                        amp_unconstrain_pcon[jj],
+                        t0_unconstrain_pcon[jj],
                         fcutoff=setup.chi2_lowfreq_fcutoff[chan_num],
                     )
 
@@ -1433,8 +1433,8 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
                     amp1 = amp_constrain[jj]
                     t01 = t0_constrain[jj]
                 elif setup.do_ofamp_unconstrained[chan_num] and setup.which_fit_pileup=="unconstrained":
-                    amp1 = amp_noconstrain[jj]
-                    t01 = t0_noconstrain[jj]
+                    amp1 = amp_unconstrain[jj]
+                    t01 = t0_unconstrain[jj]
                 elif setup.do_ofamp_nodelay[chan_num] and setup.which_fit_pileup=="nodelay":
                     amp1 = amp_nodelay[jj]
                     t01 = 0
@@ -1459,8 +1459,8 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
                     amp1 = amp_constrain_smooth[jj]
                     t01 = t0_constrain_smooth[jj]
                 elif setup.do_ofamp_unconstrained_smooth[chan_num] and setup.which_fit_pileup=="unconstrained":
-                    amp1 = amp_noconstrain_smooth[jj]
-                    t01 = t0_noconstrain_smooth[jj]
+                    amp1 = amp_unconstrain_smooth[jj]
+                    t01 = t0_unconstrain_smooth[jj]
                 elif setup.do_ofamp_nodelay_smooth[chan_num] and setup.which_fit_pileup=="nodelay":
                     amp1 = amp_nodelay_smooth[jj]
                     t01 = 0
@@ -1566,25 +1566,25 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
 
     if setup.do_ofamp_unconstrained[chan_num]:
         rq_dict[f'ofamp_unconstrain_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
-        rq_dict[f'ofamp_unconstrain_{chan}{det}'][readout_inds] = amp_noconstrain
+        rq_dict[f'ofamp_unconstrain_{chan}{det}'][readout_inds] = amp_unconstrain
         rq_dict[f't0_unconstrain_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
-        rq_dict[f't0_unconstrain_{chan}{det}'][readout_inds] = t0_noconstrain
+        rq_dict[f't0_unconstrain_{chan}{det}'][readout_inds] = t0_unconstrain
         rq_dict[f'chi2_unconstrain_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
-        rq_dict[f'chi2_unconstrain_{chan}{det}'][readout_inds] = chi2_noconstrain
+        rq_dict[f'chi2_unconstrain_{chan}{det}'][readout_inds] = chi2_unconstrain
         if setup.ofamp_unconstrained_pulse_constraint[chan_num]!=0:
             rq_dict[f'ofamp_unconstrain_pcon_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
-            rq_dict[f'ofamp_unconstrain_pcon_{chan}{det}'][readout_inds] = amp_noconstrain_pcon
+            rq_dict[f'ofamp_unconstrain_pcon_{chan}{det}'][readout_inds] = amp_unconstrain_pcon
             rq_dict[f't0_unconstrain_pcon_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
-            rq_dict[f't0_unconstrain_pcon_{chan}{det}'][readout_inds] = t0_noconstrain_pcon
+            rq_dict[f't0_unconstrain_pcon_{chan}{det}'][readout_inds] = t0_unconstrain_pcon
             rq_dict[f'chi2_unconstrain_pcon_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
-            rq_dict[f'chi2_unconstrain_pcon_{chan}{det}'][readout_inds] = chi2_noconstrain_pcon
+            rq_dict[f'chi2_unconstrain_pcon_{chan}{det}'][readout_inds] = chi2_unconstrain_pcon
     if setup.do_ofamp_unconstrained_smooth[chan_num]:
         rq_dict[f'ofamp_unconstrain_smooth_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
-        rq_dict[f'ofamp_unconstrain_smooth_{chan}{det}'][readout_inds] = amp_noconstrain_smooth
+        rq_dict[f'ofamp_unconstrain_smooth_{chan}{det}'][readout_inds] = amp_unconstrain_smooth
         rq_dict[f't0_unconstrain_smooth_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
-        rq_dict[f't0_unconstrain_smooth_{chan}{det}'][readout_inds] = t0_noconstrain_smooth
+        rq_dict[f't0_unconstrain_smooth_{chan}{det}'][readout_inds] = t0_unconstrain_smooth
         rq_dict[f'chi2_unconstrain_smooth_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
-        rq_dict[f'chi2_unconstrain_smooth_{chan}{det}'][readout_inds] = chi2_noconstrain_smooth
+        rq_dict[f'chi2_unconstrain_smooth_{chan}{det}'][readout_inds] = chi2_unconstrain_smooth
 
     if setup.do_ofamp_constrained[chan_num]:
         rq_dict[f'ofamp_constrain_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)

--- a/rqpy/sim/_trig_sim.py
+++ b/rqpy/sim/_trig_sim.py
@@ -63,19 +63,11 @@ class TrigSim(object):
         and re-arranged for input into the FIR filter code.
     fs : float
         The digitization rate of the data in Hz.
-    can_run_trigger : bool
-        A boolean flag for whether or not the `TrigSim.trigger` method can be run.
-    which_channel : int
-        The channel that the FIR filter will be triggering. Always set to zero, should not be
-        changed.
     of_coeffs : ndarray
         The coefficients of the FIR filter that will be applied to the downsampled
         data.
     _resolution : list
         The calculated resolution of the FIR filter.
-    threshold : int
-        The threshold to set for triggering on pulses, should be in the arbitrary units of the
-        filter.
     convtoadcbins : float
         The conversion factor for expressing FIR filter amplitudes in units of ADC bins.
 
@@ -112,12 +104,10 @@ class TrigSim(object):
         self.input_psds = [psd]*12 + [np.ones(4*len(psd))]*4
         self.input_pulse_shapes = [template]*12 + [np.zeros(4*template.shape[0])]*4
         self.fs = fs
-        self.can_run_trigger = False
-        self.threshold = 0
 
         raw_LC_coeffs = np.zeros((4,16))
-        self.which_channel = 0
-        raw_LC_coeffs[0, self.which_channel] = 1 # only one phonon channel
+        which_channel = 0
+        raw_LC_coeffs[0, which_channel] = 1 # only one phonon channel
         LC_coeffs = trigsim.scale_max(raw_LC_coeffs, bits=8, axis=1)
         TrL_requires = np.zeros((8,16), dtype=bool)
         TrL_vetos = np.zeros((8,16), dtype=bool)
@@ -194,7 +184,7 @@ class TrigSim(object):
 
         Returns
         -------
-        resolution : ndarray
+        resolution : list
             The resolution of the FIR filter.
 
         """
@@ -202,51 +192,6 @@ class TrigSim(object):
         self._resolution = self._Trigger.resolution(self.input_psds, deltaT_phonon=1/self.fs)
 
         return self._resolution
-
-    def set_threshold(self, threshold):
-        """
-        Method for calculation the resolution of the FIR filter in the arbitrary units of the filter.
-
-        Parameters
-        ----------
-        threshold : float
-            The threshold to set for triggering on pulses, should be in the arbitrary units of the
-            filter.
-
-        Notes
-        -----
-        For this function, if the trigger is already known, then it is recommended that the user
-        calculate the resolution of the FIR filter using the `TrigSim.resolution` method. The output
-        of that function times the number of standard deviations desired can then be directly passed 
-        to this function.
-
-        Examples
-        --------
-        >>> import rqpy as rp
-
-        Load the PSD, template, and fs for passing to `TrigSim`.
-
-        >>> psd, template, fs = my_load_function('/path/to/data/file.ext')
-        >>> TS = rp.sim.TrigSim(psd, template, fs)
-        >>> resolution = TS.resolution()
-
-        Set the treshold to a 5-sigma threshold.
-
-        >>> TS.set_threshold(5*resolution[0])
-
-        Now the `TrigSim.trigger` method can be run on some data, where we have a 5-sigma trigger
-        threshold.
-
-        """
-
-        self.threshold = threshold
-
-        if np.isscalar(threshold):
-            threshold = (~np.all(~self.of_coeffs, axis=1)).astype(float)*threshold
-
-        self._Trigger.ThL.ThLs[self.which_channel].set_thresholds(np.int64(threshold), 0)
-
-        self.can_run_trigger = True
 
     def trigger(self, x, k=12):
         """
@@ -270,20 +215,15 @@ class TrigSim(object):
             The time of the triggered pulse as calculated by the FIR filter, in s. Taken as the bin
             number of the maximum amplitude within the valid part of the trace divided by the
             downsampled digitization rate.
+        fir_nodelay : float
+            The OF amplitude at the center of the trace, taken as the center value of FIR filtered
+            trace. This is equivalent to the no time-shifting OF amplitude, using the FIR filter
+            output.
         fir_out : ndarray
             The complete, filtered trace corresponding to the inputted trace, in the arbitrary
             units of the filter.
 
-        Raises
-        ------
-        ValueError
-            If the `TrigSim.set_threshold` method was not used to set the trigger threshold,
-            then an error is thrown because the trigger is not properly set up.
-
         """
-
-        if not self.can_run_trigger:
-            raise ValueError("The threshold was not set, please use the TrigSim.set_threshold method.")
 
         input_traces = [(x[k:] - 32768).astype('int64')] + [np.zeros(len(x[k:]),dtype='int64')]*11 + \
                        [np.zeros(4*len(x[k:]),dtype='int64')]*4
@@ -293,14 +233,12 @@ class TrigSim(object):
         pipe = trigsim.pipeline(self._Trigger.DF, self._Trigger.LC, self._Trigger.LC_trunc, 
                                 self._Trigger.FIR, self._Trigger.FIR_trunc)
 
-        fir_out = pipe.send(input_traces)
-
         bins_to_keep = (len(x) - k)//16 - 1024
 
-        if any(fir_out[0, -bins_to_keep:] >= self.threshold):
-            triggeramp = fir_out[0, -bins_to_keep:].max()
-            triggertime = (np.argmax(fir_out[0, -bins_to_keep:]) + 512 + k / 16) / (self.fs / 16)
+        fir_out = pipe.send(input_traces)[0, -bins_to_keep:]
 
-            return triggeramp, triggertime, fir_out[0, -bins_to_keep:]
-        else:
-            return 0, 0, fir_out[0, -bins_to_keep:]
+        triggeramp = fir_out.max()
+        triggertime = (np.argmax(fir_out) + 513 + k / 16) / (self.fs / 16)
+        fir_nodelay = fir_out[len(fir_out)//2 - 1 + len(fir_out)%2]
+
+        return triggeramp, triggertime, fir_nodelay, fir_out

--- a/rqpy/sim/_trig_sim.py
+++ b/rqpy/sim/_trig_sim.py
@@ -138,7 +138,7 @@ class TrigSim(object):
                                     TrL_enables=np.array([1,0,0,0,0,0,0,0], dtype=bool),
                                     TrL_requires=TrL_requires, TrL_vetos=TrL_vetos,
                                     TrL_prescales=np.ones(8, dtype='float'))
-        
+
         self.of_coeffs = self._Trigger.build_OF_coeffs(self.input_psds, self.input_pulse_shapes)
         self._Trigger.set_FIR_coeffs(self.of_coeffs)
         self.convtoadcbins = self._convtoadcbins(fir_bits_out, fir_discard_msbs)
@@ -200,7 +200,7 @@ class TrigSim(object):
         """
 
         self._resolution = self._Trigger.resolution(self.input_psds, deltaT_phonon=1/self.fs)
-        
+
         return self._resolution
 
     def set_threshold(self, threshold):


### PR DESCRIPTION
I've made significant changes to two files.

`rqpy/sim/_trigsim.py`
- Remove trigger threshold method `TrigSim.set_threshold` (user can do the trigger threshold cut offline)
- Add the calculation of the zero time shifting OF amplitude from the FIR filter (for comparison of resolution to other energy estimators), this is returned by `TrigSim.trigger` by default now

`rqpy/process/_process_rq.py`
- Refactor the shifted OF amplitude code to use the optional parameter `windowcenter` in `qetpy.OptimumFilter.ofamp_nodelay`
- Add `windowcenter` to all of the constrained optimum filters (constrained, pileup, baseline), resolves #96 
- Add ability to specify fit used as the non-pileup pulse for the pileup Optimum Filter, resolves #99 

There are also various white space and typo fixes.
