### PR TITLE
Add windowcenter to arg length check

### DIFF
--- a/rqpy/process/_process_rq.py
+++ b/rqpy/process/_process_rq.py
@@ -654,7 +654,7 @@ class SetupRQ(object):
 
         """
 
-        lgcrun, lgcrun_smooth, nconstrain, pulse_direction_constraint = self._check_arg_length(
+        lgcrun, lgcrun_smooth, nconstrain, windowcenter, pulse_direction_constraint = self._check_arg_length(
             lgcrun=lgcrun,
             lgcrun_smooth=lgcrun_smooth,
             nconstrain=nconstrain,
@@ -705,7 +705,7 @@ class SetupRQ(object):
 
         """
 
-        lgcrun, lgcrun_smooth, nconstrain, pulse_direction_constraint = self._check_arg_length(
+        lgcrun, lgcrun_smooth, nconstrain, windowcenter, pulse_direction_constraint = self._check_arg_length(
             lgcrun=lgcrun,
             lgcrun_smooth=lgcrun_smooth,
             nconstrain=nconstrain,
@@ -758,7 +758,7 @@ class SetupRQ(object):
 
         """
 
-        lgcrun, lgcrun_smooth, nconstrain, pulse_direction_constraint = self._check_arg_length(
+        lgcrun, lgcrun_smooth, nconstrain, windowcenter, pulse_direction_constraint = self._check_arg_length(
             lgcrun=lgcrun,
             lgcrun_smooth=lgcrun_smooth,
             nconstrain=nconstrain,


### PR DESCRIPTION
Accidentally forgot to push this commit before requesting the merge for #114. Fixing the arg length check of the `windowcenter` parameter.