### PR TITLE
Add confidence ellipse plotting 

### DIFF
--- a/rqpy/plotting/_core_plotting.py
+++ b/rqpy/plotting/_core_plotting.py
@@ -883,7 +883,7 @@ def conf_ellipse(mu, cov, conf=0.68, ax=None, **kwargs):
         kwargs['fill'] = False
 
     if 'zorder' not in kwargs:
-        kwargs['zorder'] = max(lc.get_zorder() for lc in ax.lines + ax.collections) + 1
+        kwargs['zorder'] = max(lc.get_zorder() for lc in ax.lines + ax.collections) + 0.1
 
     a, v = np.linalg.eig(cov)
     v0 = v[:,0]

--- a/rqpy/plotting/_core_plotting.py
+++ b/rqpy/plotting/_core_plotting.py
@@ -883,7 +883,7 @@ def conf_ellipse(mu, cov, conf=0.68, ax=None, **kwargs):
         kwargs['fill'] = False
 
     if 'zorder' not in kwargs:
-        kwargs['zorder'] = max(lc.get_zorder() for lc in ax.lines + ax.collections)
+        kwargs['zorder'] = max(lc.get_zorder() for lc in ax.lines + ax.collections) + 1
 
     a, v = np.linalg.eig(cov)
     v0 = v[:,0]

--- a/rqpy/plotting/_core_plotting.py
+++ b/rqpy/plotting/_core_plotting.py
@@ -798,7 +798,7 @@ class RatePlot(RQpyPlot):
 
         self._update_colors("--")
 
-def conf_ellipse(mu, cov, conf=0.68, ax=None, **kwargs):
+def conf_ellipse(mu, cov, conf=0.683, ax=None, **kwargs):
     """
     Draw a 2-D confidence level ellipse based on a mean, covariance matrix,
     and specified confidence level.
@@ -811,7 +811,7 @@ def conf_ellipse(mu, cov, conf=0.68, ax=None, **kwargs):
         A 2-by-2 covariance matrix describing the relation of the x and y variables.
     conf : float
         The confidence level at which to draw the ellipse. Should be a value between
-        0 and 1. Default is 0.68.
+        0 and 1. Default is 0.683. See Notes for more information
     ax : axes.Axes object, NoneType, optional
         Option to pass an existing Matplotlib Axes object to plot over, if it already exists.
     **kwargs
@@ -831,6 +831,19 @@ def conf_ellipse(mu, cov, conf=0.68, ax=None, **kwargs):
 
     Notes
     -----
+    When deciding the value for `conf`, the standard frequentist statement about what this contour means is:
+
+        "If the experiment is repeated many times with the same statistical analysis, then the
+        contour (which will in general be different for each realization of the experiment) will
+        define a region which contains the true value in 68.3% of the experiments."
+
+    Note that the 68.3% confidence level contour in 2 dimensions is not the same as 1-sigma contour. The
+    1-sigma contour for 2 dimensions (i.e. the value by which the chi^2 value increases by 1) contains
+    the true value in 39.3% of the experiments.
+
+    More discussion on multi-parameter errors can be found here:
+        http://seal.web.cern.ch/seal/documents/minuit/mnerror.pdf
+
     The valid keyword arguments are below (taken from the Ellipse docstring). In this function, `fill` is
     defaulted to False and 'zorder' is defaulted so that the ellipse is be on top of previous plots.
         agg_filter: a filter function, which takes a (m, n, 3) float array and a dpi value, and returns a (m, n, 3) array

--- a/rqpy/plotting/_core_plotting.py
+++ b/rqpy/plotting/_core_plotting.py
@@ -874,6 +874,9 @@ def conf_ellipse(mu, cov, conf=0.68, ax=None, **kwargs):
 
     if ax is None:
         fig, ax = plt.subplots(figsize=(9, 6))
+        ax.grid()
+        ax.grid(which="minor", axis="both", linestyle="dotted")
+        ax.tick_params(which="both", direction="in", right=True, top=True)
         autoscale_axes = True
     else:
         fig = None
@@ -882,7 +885,7 @@ def conf_ellipse(mu, cov, conf=0.68, ax=None, **kwargs):
     if 'fill' not in kwargs:
         kwargs['fill'] = False
 
-    if 'zorder' not in kwargs:
+    if 'zorder' not in kwargs and len(ax.lines + ax.collections) > 0:
         kwargs['zorder'] = max(lc.get_zorder() for lc in ax.lines + ax.collections) + 0.1
 
     a, v = np.linalg.eig(cov)

--- a/rqpy/plotting/_core_plotting.py
+++ b/rqpy/plotting/_core_plotting.py
@@ -554,7 +554,7 @@ def densityplot(xvals, yvals, xlims=None, ylims=None, nbins = (500,500), cut=Non
     cax = ax.hist2d(xvals[limitcut & cut], yvals[limitcut & cut], bins=nbins,
                     norm=norm, cmap=cmap)
     cbar = fig.colorbar(cax[-1], label = 'Density of Data')
-    cbar.ax.tick_params(direction="in")
+    cbar.ax.tick_params(which="both", direction="in")
     ax.ticklabel_format(style='sci', axis='x', scilimits=(0, 0))
     ax.ticklabel_format(style='sci', axis='y', scilimits=(0, 0))
     ax.tick_params(which="both", direction="in", right=True, top=True)
@@ -831,7 +831,8 @@ def conf_ellipse(mu, cov, conf=0.68, ax=None, **kwargs):
 
     Notes
     -----
-    The valid keyword arguments are (taken from the Ellipse docstring). In this function, `fill` is defaulted to False.
+    The valid keyword arguments are below (taken from the Ellipse docstring). In this function, `fill` is
+    defaulted to False and 'zorder' is defaulted so that the ellipse is be on top of previous plots.
         agg_filter: a filter function, which takes a (m, n, 3) float array and a dpi value, and returns a (m, n, 3) array
         alpha: float or None
         animated: bool
@@ -873,11 +874,16 @@ def conf_ellipse(mu, cov, conf=0.68, ax=None, **kwargs):
 
     if ax is None:
         fig, ax = plt.subplots(figsize=(9, 6))
+        autoscale_axes = True
     else:
         fig = None
+        autoscale_axes = False
 
     if 'fill' not in kwargs:
         kwargs['fill'] = False
+
+    if 'zorder' not in kwargs:
+        kwargs['zorder'] = max(lc.get_zorder() for lc in ax.lines + ax.collections)
 
     a, v = np.linalg.eig(cov)
     v0 = v[:,0]
@@ -895,6 +901,9 @@ def conf_ellipse(mu, cov, conf=0.68, ax=None, **kwargs):
         **kwargs,
     )
 
-    ax_ell = ax.add_artist(ell)
+    ax_ell = ax.add_patch(ell)
+
+    if autoscale_axes:
+        ax.autoscale()
 
     return fig, ax

--- a/rqpy/plotting/_core_plotting.py
+++ b/rqpy/plotting/_core_plotting.py
@@ -824,6 +824,11 @@ def conf_ellipse(mu, cov, conf=0.68, ax=None, **kwargs):
     ax : axes.Axes object
         Matplotlib Axes object
 
+    Raises
+    ------
+    ValueError
+        If `conf` is not in the range [0, 1]
+
     Notes
     -----
     The valid keyword arguments are (taken from the Ellipse docstring). In this function, `fill` is defaulted to False.
@@ -862,6 +867,9 @@ def conf_ellipse(mu, cov, conf=0.68, ax=None, **kwargs):
 
     if isinstance(mu, np.ndarray):
         mu = mu.tolist()
+
+    if not rp.inrange(conf, 0, 1):
+        raise ValueError("conf should be in the range [0, 1]")
 
     if ax is None:
         fig, ax = plt.subplots(figsize=(9, 6))


### PR DESCRIPTION
Added the function `rqpy.conf_ellipse` to `rqpy/plotting/_core_plotting.py`. Given a mean, covariance matrix, and some confidence level, the function plots the ellipse that contains the amount of data determined by the confidence level, assuming a 2-dimensional normal distribution.