### PR TITLE
Fix x values definition in rqpy.limit.gauss_smear

### DIFF
--- a/rqpy/limit/_limit.py
+++ b/rqpy/limit/_limit.py
@@ -301,7 +301,7 @@ def gauss_smear(x, f, res, nres=1e5, gauss_width=10):
     gauss = stats.norm.pdf(xgauss, scale=res)
 
     sce = signal.convolve(f2(x2), gauss, mode="full", method="direct") * spacing
-    e_conv = np.arange(-gauss_width*res, gauss_width*res + x2[-1]-x2[0], spacing)
+    e_conv = np.arange(-gauss_width * res + x2[0], gauss_width * res + x2[-1], spacing)
     s = interpolate.interp1d(e_conv, sce)
 
     return s(x)


### PR DESCRIPTION
I noticed that the the x values of the `gauss_smear` function were actually incorrectly defined, which would lead to slightly incorrect smeared distributions. Not a huge effect on previous results, but this should be correct now.