### PR TITLE
Refactor and improve drde_gauss_smear2d

### DIFF
--- a/rqpy/limit/_limit.py
+++ b/rqpy/limit/_limit.py
@@ -538,23 +538,23 @@ def drde_gauss_smear2d(x, cov, delta, m_dm, sig0, nsig=3, tm="Si"):
             1,
         ) * _norm2d_trunc(
             val,
-            e0,
             et,
+            e0,
             cov,
             nsig,
         ) * drde(e0, m_dm, sig0, tm=tm)
 
         # get x values inside ellipse for each y value
         etvals = []
-        for en in e0:
+        for en in y:
             if rp.inrange(val, en - ep_top, en + ep_top):
                 ets = np.linspace(en - et_top, en + et_top, num=100)
-                etvals.append([en, ets])
+                etvals.append([ets, en])
 
         # evaluate double integral
         if len(etvals) > 0:
             temp_out = 0
-            for en, ets in etvals:
+            for ets, en in etvals:
                 temp_out += np.sum(func(ets, en)) * np.diff(ets).mean() * ydiff
             out[ii] = temp_out
 


### PR DESCRIPTION
I've refactored the code for `rqpy.limit.drde_gauss_smear2d` so that the code does a better job at calculating the smeared dR/dE using a 2D normal distribution. I also fixed a bug that was affecting the smearing. The explicit changes are detailed below.

- remove `rqpy.limit._limit._largest_et` function
- change calculation of the integral bounds in the trigger energy estimator
- make sure that the true energy is integrated in 1 eV bins
- change the heaviside theta function so that it is evaluated as 1 at threshold
- fix bug in the lambda function defining the double integral so that the true energy is inputted correctly

I've done some testing for different levels of smearing and compared to data, and the code seems to be working well.