### PR TITLE
Add ability to fix taurise in nonlinear OF processing

### DIFF
--- a/rqpy/process/_process_rq.py
+++ b/rqpy/process/_process_rq.py
@@ -1624,7 +1624,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
                                 flip * s[maxind + 1:maxind + 1 + int(300e-6 * setup.fs)] - tauval,
                             ),
                         ) + maxind + 1
-                        taufallguess = (tauind - maxind) / self.fs
+                        taufallguess = (tauind - maxind) / setup.fs
                         tauriseguess = 20e-6
                         guess = (
                             np.abs(amp_constrain[jj]),
@@ -1662,7 +1662,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
                                 flip * s[maxind + 1:maxind + 1 + int(300e-6 * setup.fs)] - tauval,
                             ),
                         ) + maxind + 1
-                        taufallguess = (tauind - maxind) / self.fs
+                        taufallguess = (tauind - maxind) / setup.fs
                         guess = (
                             np.abs(amp_constrain[jj]),
                             taufallguess,

--- a/rqpy/process/_process_rq.py
+++ b/rqpy/process/_process_rq.py
@@ -1617,6 +1617,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
 
                 if setup.taurise[chan_num] is None:
                     if setup.do_ofamp_constrained[chan_num]:
+                        maxind = int(t0_constrain[jj] * setup.fs) + len(s)//2
                         tauval = np.abs(amp_constrain[jj]) / np.e
                         tauind = np.argmin(
                             np.abs(
@@ -1654,6 +1655,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
                     success_nonlin[jj] = res_nlin[4]
                 else:
                     if setup.do_ofamp_constrained[chan_num]:
+                        maxind = int(t0_constrain[jj] * setup.fs) + len(s)//2
                         tauval = np.abs(amp_constrain[jj]) / np.e
                         tauind = np.argmin(
                             np.abs(

--- a/rqpy/process/_process_rq.py
+++ b/rqpy/process/_process_rq.py
@@ -1620,7 +1620,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
                         tauval = np.abs(amp_constrain[jj]) / np.e
                         tauind = np.argmin(
                             np.abs(
-                                pulse[maxind + 1:maxind + 1 + int(300e-6 * setup.fs)] - tauval,
+                                flip * s[maxind + 1:maxind + 1 + int(300e-6 * setup.fs)] - tauval,
                             ),
                         ) + maxind + 1
                         taufallguess = (tauind - maxind) / self.fs
@@ -1657,7 +1657,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
                         tauval = np.abs(amp_constrain[jj]) / np.e
                         tauind = np.argmin(
                             np.abs(
-                                pulse[maxind + 1:maxind + 1 + int(300e-6 * setup.fs)] - tauval,
+                                flip * s[maxind + 1:maxind + 1 + int(300e-6 * setup.fs)] - tauval,
                             ),
                         ) + maxind + 1
                         taufallguess = (tauind - maxind) / self.fs


### PR DESCRIPTION
Added an extra feature to RQ processing for the nonlinear OF.

- Can now specify a fixed `taurise` to reduce the number of degrees of freedom, if desired.
- The guesses for the nonlinear OF are now set based on the constrained OF fit (if run)