### PR TITLE
Add a constrained FIR trigger amplitude calculation, allow multichannel trigger simulation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ lmfit>=0.9.13
 mendeleev>=0.4.5
 qetpy>=1.1.0
 deepdish>=0.3.6
+scikit_learn>=0.20.2

--- a/rqpy/process/_process_rq.py
+++ b/rqpy/process/_process_rq.py
@@ -1933,10 +1933,10 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
         rq_dict[f'ofamp_nodelay_sim_{chan}{det}'][readout_inds] = ofampnodelay_sim
 
         if setup.do_trigsim_constrained[chan_num]:
-            rq_dict[f'triggeramp_sim_constrained{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
-            rq_dict[f'triggeramp_sim_constrained{chan}{det}'][readout_inds] = triggeramp_sim_constrained
-            rq_dict[f'triggertime_sim_constrained{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
-            rq_dict[f'triggertime_sim_constrained{chan}{det}'][readout_inds] = triggertime_sim_constrained
+            rq_dict[f'triggeramp_sim_constrained_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
+            rq_dict[f'triggeramp_sim_constrained_{chan}{det}'][readout_inds] = triggeramp_sim_constrained
+            rq_dict[f'triggertime_sim_constrained_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
+            rq_dict[f'triggertime_sim_constrained_{chan}{det}'][readout_inds] = triggertime_sim_constrained
 
     if setup.do_ofamp_coinc[chan_num] and setup.trigger is not None and chan_num!=setup.trigger:
         rq_dict[f'ofamp_coinc_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)

--- a/rqpy/process/_process_rq.py
+++ b/rqpy/process/_process_rq.py
@@ -422,7 +422,7 @@ class SetupRQ(object):
 
         self.do_ofamp_shifted = [False]*self.nchan
         self.do_ofamp_shifted_smooth = [False]*self.nchan
-        self.ofamp_shifted_lowfreqchi2 = [True]*self.nchan
+        self.ofamp_shifted_lowfreqchi2 = True
         self.ofamp_shifted_binshift = [0]*self.nchan
 
         self.do_baseline = [True]*self.nchan
@@ -1493,15 +1493,15 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
             if setup.do_ofamp_nodelay[chan_num]:
                 amp_nodelay[jj], chi2_nodelay[jj] = OF.ofamp_nodelay()
 
+                if setup.ofamp_nodelay_lowfreqchi2 and setup.do_chi2_lowfreq[chan_num]:
+                    chi2low_nodelay[jj] = OF.chi2_lowfreq(
+                        amp_nodelay[jj],
+                        0,
+                        fcutoff=setup.chi2_lowfreq_fcutoff[chan_num],
+                    )
+
             if setup.do_ofamp_nodelay_smooth[chan_num]:
                 amp_nodelay_smooth[jj], chi2_nodelay_smooth[jj] = OF_smooth.ofamp_nodelay()
-
-            if setup.ofamp_nodelay_lowfreqchi2 and setup.do_chi2_lowfreq[chan_num]:
-                chi2low_nodelay[jj] = OF.chi2_lowfreq(
-                    amp_nodelay[jj],
-                    0,
-                    fcutoff=setup.chi2_lowfreq_fcutoff[chan_num],
-                )
 
             if setup.do_ofamp_unconstrained[chan_num]:
                 amp_unconstrain[jj], t0_unconstrain[jj], chi2_unconstrain[jj] = OF.ofamp_withdelay()
@@ -1509,22 +1509,21 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
                     amp_unconstrain_pcon[jj], t0_unconstrain_pcon[jj], chi2_unconstrain_pcon[jj] = OF.ofamp_withdelay(
                         pulse_direction_constraint=setup.ofamp_unconstrained_pulse_constraint[chan_num],
                     )
+                if setup.ofamp_unconstrained_lowfreqchi2 and setup.do_chi2_lowfreq[chan_num]:
+                    chi2low_unconstrain[jj] = OF.chi2_lowfreq(
+                        amp_unconstrain[jj],
+                        t0_unconstrain[jj],
+                        fcutoff=setup.chi2_lowfreq_fcutoff[chan_num],
+                    )
+                    if setup.ofamp_unconstrained_pulse_constraint[chan_num]!=0:
+                        chi2low_unconstrain_pcon[jj] = OF.chi2_lowfreq(
+                            amp_unconstrain_pcon[jj],
+                            t0_unconstrain_pcon[jj],
+                            fcutoff=setup.chi2_lowfreq_fcutoff[chan_num],
+                        )
 
             if setup.do_ofamp_unconstrained_smooth[chan_num]:
                 amp_unconstrain_smooth[jj], t0_unconstrain_smooth[jj], chi2_unconstrain_smooth[jj] = OF_smooth.ofamp_withdelay()
-
-            if setup.ofamp_unconstrained_lowfreqchi2 and setup.do_chi2_lowfreq[chan_num]:
-                chi2low_unconstrain[jj] = OF.chi2_lowfreq(
-                    amp_unconstrain[jj],
-                    t0_unconstrain[jj],
-                    fcutoff=setup.chi2_lowfreq_fcutoff[chan_num],
-                )
-                if setup.ofamp_unconstrained_pulse_constraint[chan_num]!=0:
-                    chi2low_unconstrain_pcon[jj] = OF.chi2_lowfreq(
-                        amp_unconstrain_pcon[jj],
-                        t0_unconstrain_pcon[jj],
-                        fcutoff=setup.chi2_lowfreq_fcutoff[chan_num],
-                    )
 
             if setup.do_ofamp_constrained[chan_num]:
                 amp_constrain[jj], t0_constrain[jj], chi2_constrain[jj] = OF.ofamp_withdelay(
@@ -1537,25 +1536,24 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
                         pulse_direction_constraint=setup.ofamp_constrained_pulse_constraint[chan_num],
                         windowcenter=setup.ofamp_constrained_windowcenter[chan_num],
                     )
+                if setup.ofamp_constrained_lowfreqchi2 and setup.do_chi2_lowfreq[chan_num]:
+                    chi2low_constrain[jj] = OF.chi2_lowfreq(
+                        amp_constrain[jj],
+                        t0_constrain[jj],
+                        fcutoff=setup.chi2_lowfreq_fcutoff[chan_num],
+                    )
+                    if setup.ofamp_constrained_pulse_constraint[chan_num]!=0:
+                        chi2low_constrain_pcon[jj] = OF.chi2_lowfreq(
+                            amp_constrain_pcon[jj],
+                            t0_constrain_pcon[jj],
+                            fcutoff=setup.chi2_lowfreq_fcutoff[chan_num],
+                        )
 
             if setup.do_ofamp_constrained_smooth[chan_num]:
                 amp_constrain_smooth[jj], t0_constrain_smooth[jj], chi2_constrain_smooth[jj] = OF_smooth.ofamp_withdelay(
                     nconstrain=setup.ofamp_constrained_nconstrain[chan_num],
                     windowcenter=setup.ofamp_constrained_windowcenter[chan_num],
                 )
-
-            if setup.ofamp_constrained_lowfreqchi2 and setup.do_chi2_lowfreq[chan_num]:
-                chi2low_constrain[jj] = OF.chi2_lowfreq(
-                    amp_constrain[jj],
-                    t0_constrain[jj],
-                    fcutoff=setup.chi2_lowfreq_fcutoff[chan_num],
-                )
-                if setup.ofamp_constrained_pulse_constraint[chan_num]!=0:
-                    chi2low_constrain_pcon[jj] = OF.chi2_lowfreq(
-                        amp_constrain_pcon[jj],
-                        t0_constrain_pcon[jj],
-                        fcutoff=setup.chi2_lowfreq_fcutoff[chan_num],
-                    )
 
             if setup.do_ofamp_pileup[chan_num]:
                 if setup.do_ofamp_constrained[chan_num] and setup.which_fit_pileup=="constrained":
@@ -1634,12 +1632,12 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
                     windowcenter=setup.ofamp_shifted_binshift[chan_num],
                 )
 
-            if setup.ofamp_shifted_lowfreqchi2 and setup.do_chi2_lowfreq[chan_num]:
-                chi2low_shifted[jj] = OF.chi2_lowfreq(
-                    amp_shifted[jj],
-                    setup.ofamp_shifted_binshift[chan_num] / fs,
-                    fcutoff=setup.chi2_lowfreq_fcutoff[chan_num],
-                )
+                if setup.ofamp_shifted_lowfreqchi2 and setup.do_chi2_lowfreq[chan_num]:
+                    chi2low_shifted[jj] = OF.chi2_lowfreq(
+                        amp_shifted[jj],
+                        setup.ofamp_shifted_binshift[chan_num] / fs,
+                        fcutoff=setup.chi2_lowfreq_fcutoff[chan_num],
+                    )
 
             if setup.do_ofamp_shifted_smooth[chan_num]:
                 amp_shifted_smooth[jj], chi2_shifted_smooth[jj] = OF_smooth.ofamp_nodelay(

--- a/rqpy/sim/_trig_sim.py
+++ b/rqpy/sim/_trig_sim.py
@@ -89,7 +89,7 @@ class TrigSim(object):
             a 2D array containing the template for each channel that is being used in the trigger.
         fs : float
             The digitization rate of the data in Hz.
-        which_channel : int, array_like
+        which_channel : int, array_like, optional
             The index or array of indices that specify which channels will be used to
             trigger on. Default is zero, specifying just a single channel.
         fir_bits_out : int, optional

--- a/rqpy/sim/_trig_sim.py
+++ b/rqpy/sim/_trig_sim.py
@@ -288,7 +288,10 @@ class TrigSim(object):
 
         nconstrain = int(constraint_width * (self.fs / 16))
         if nconstrain == 0:
-            raise ValueError(f"The inputted constraint_width should be greater than {16 / self.fs}, so that")
+            raise ValueError(
+                f"The inputted constraint_width should be greater than {16 / self.fs}, "
+                "so that we include more than one bin of the trace."
+            )
 
         windowcenter_int = round(windowcenter * (self.fs / 16))
 

--- a/rqpy/sim/_trig_sim.py
+++ b/rqpy/sim/_trig_sim.py
@@ -111,7 +111,7 @@ class TrigSim(object):
         self.fs = fs
 
         raw_LC_coeffs = np.zeros((4,16))
-        which_channel = 0
+        raw_LC_coeffs[0, which_channel] = 1
         LC_coeffs = trigsim.scale_max(raw_LC_coeffs, bits=8, axis=1)
         TrL_requires = np.zeros((8,16), dtype=bool)
         TrL_vetos = np.zeros((8,16), dtype=bool)

--- a/rqpy/sim/_trig_sim.py
+++ b/rqpy/sim/_trig_sim.py
@@ -254,7 +254,7 @@ class TrigSim(object):
             The input array to run the FIR filter on. Should be a 1-d ndarray in units of 
             ADC bins.
         constraint_width : float
-            The width, in seconds, of this window that the constraint on the FIR amplitude will be set by.
+            The width, in seconds, of the window that the constraint on the FIR amplitude will be set by.
         k : int, optional
             The bin number to start the FIR filter at. Since the filter downsamples the data
             by a factor of 16, the starting bin has a small effect on the calculated amplitude.

--- a/rqpy/sim/_trig_sim.py
+++ b/rqpy/sim/_trig_sim.py
@@ -116,22 +116,36 @@ class TrigSim(object):
         TrL_requires = np.zeros((8,16), dtype=bool)
         TrL_vetos = np.zeros((8,16), dtype=bool)
 
-        self._Trigger = trigsim.Trigger(bits_phonon=16, bits_charge=16,
-                                        phonon_DF_R=16, phonon_DF_N=3, phonon_DF_M=1, phonon_start=0,
-                                        charge_DF_R=64, charge_DF_N=3, charge_DF_M=1, charge_start=0,
-                                        LC_coeffs=LC_coeffs, LC_bits_out=46,
-                                        LC_bits_coeff=8, LC_discard_MSBs=[0,0,0,0],
-                                        FIR_coeffs=np.zeros((4,1024), 'i8'), FIR_bits_out=fir_bits_out, 
-                                        FIR_bits_coeff=16, FIR_discard_MSBs=[fir_discard_msbs,0,0,0],
-                                        ThL_selectors=np.array([0,1,2,3,1,1,2,3], dtype='uint'),
-                                        ThL_activation_thresholds   = (2**15 - 1)*np.ones(8, int),
-                                        ThL_deactivation_thresholds = np.zeros(8, int),
-                                        PS_max_window_lengths=(2**31 - 1)*np.ones(4, dtype='uint'),
-                                        PS_saturated_pulse_offsets=np.zeros(4, dtype='uint'),
-                                        TrL_selectors=np.array([0,1,2,3,1,1,2,3], dtype='uint'),
-                                        TrL_enables=np.array([1,0,0,0,0,0,0,0], dtype=bool),
-                                        TrL_requires=TrL_requires, TrL_vetos=TrL_vetos,
-                                        TrL_prescales=np.ones(8, dtype='float'))
+        self._Trigger = trigsim.Trigger(
+            bits_phonon=16,
+            bits_charge=16,
+            phonon_DF_R=16,
+            phonon_DF_N=3,
+            phonon_DF_M=1,
+            phonon_start=0,
+            charge_DF_R=64,
+            charge_DF_N=3,
+            charge_DF_M=1,
+            charge_start=0,
+            LC_coeffs=LC_coeffs,
+            LC_bits_out=46,
+            LC_bits_coeff=8,
+            LC_discard_MSBs=[0, 0, 0, 0],
+            FIR_coeffs=np.zeros((4, 1024), 'i8'),
+            FIR_bits_out=fir_bits_out,
+            FIR_bits_coeff=16,
+            FIR_discard_MSBs=[fir_discard_msbs, 0, 0, 0],
+            ThL_selectors=np.array([0, 1, 2, 3, 1, 1, 2, 3], dtype='uint'),
+            ThL_activation_thresholds=(2**15 - 1) * np.ones(8, dtype=int),
+            ThL_deactivation_thresholds=np.zeros(8, dtype=int),
+            PS_max_window_lengths=(2**31 - 1) * np.ones(4, dtype='uint'),
+            PS_saturated_pulse_offsets=np.zeros(4, dtype='uint'),
+            TrL_selectors=np.array([0, 1, 2, 3, 1, 1, 2, 3], dtype='uint'),
+            TrL_enables=np.array([1, 0, 0, 0, 0, 0, 0, 0], dtype=bool),
+            TrL_requires=TrL_requires,
+            TrL_vetos=TrL_vetos,
+            TrL_prescales=np.ones(8, dtype='float'),
+        )
 
         self.of_coeffs = self._Trigger.build_OF_coeffs(self.input_psds, self.input_pulse_shapes)
         self._Trigger.set_FIR_coeffs(self.of_coeffs)
@@ -230,8 +244,9 @@ class TrigSim(object):
         Parameters
         ----------
         x : ndarray
-            The input array to run the FIR filter on. Should be a 1-d ndarray in units of 
-            ADC bins.
+            The input array to run the FIR filter on. Can be a 1 or 2D ndarray in units of 
+            ADC bins. Should be 2D if multiple channels are being triggered on, where the ndarray
+            should be all of the available channels.
         k : int, optional
             The bin number to start the FIR filter at. Since the filter downsamples the data
             by a factor of 16, the starting bin has a small effect on the calculated amplitude.
@@ -266,8 +281,13 @@ class TrigSim(object):
 
         self._Trigger.reset()
 
-        pipe = trigsim.pipeline(self._Trigger.DF, self._Trigger.LC, self._Trigger.LC_trunc, 
-                                self._Trigger.FIR, self._Trigger.FIR_trunc)
+        pipe = trigsim.pipeline(
+            self._Trigger.DF,
+            self._Trigger.LC,
+            self._Trigger.LC_trunc,
+            self._Trigger.FIR,
+            self._Trigger.FIR_trunc,
+        )
 
         bins_to_keep = (len(x) - k)//16 - 1024
 
@@ -287,8 +307,9 @@ class TrigSim(object):
         Parameters
         ----------
         x : ndarray
-            The input array to run the FIR filter on. Should be a 1-d ndarray in units of 
-            ADC bins.
+            The input array to run the FIR filter on. Can be a 1- or 2-D ndarray in units of 
+            ADC bins. Should be 2D if multiple channels are being triggered on, where the ndarray
+            should be all of the available channels.
         constraint_width : float
             The width, in seconds, of the window that the constraint on the FIR amplitude will be set by.
         k : int, optional

--- a/rqpy/sim/_trig_sim.py
+++ b/rqpy/sim/_trig_sim.py
@@ -255,7 +255,11 @@ class TrigSim(object):
 
         """
 
-        input_traces = [(xx[k:] - 32768).astype('int64') for xx in x]
+        if len(x.shape) > 1:
+            input_traces = [(xx[k:] - 32768).astype('int64') for xx in x]
+        else:
+            input_traces = [(x[k:] - 32768).astype('int64')]
+
         filled_channels = len(input_traces)
         input_traces += [np.zeros(x[..., k:].shape[-1],dtype='int64')] * (12 - filled_channels)
         input_traces += [np.zeros(4 * x[..., k:].shape[-1],dtype='int64')] * 4
@@ -316,7 +320,7 @@ class TrigSim(object):
         """
 
         if fir_out is None:
-            fir_out = self.Trigger(x, k=k)[-1]
+            fir_out = self.trigger(x, k=k)[-1]
 
         nconstrain = int(constraint_width * (self.fs / 16))
         if nconstrain == 0:


### PR DESCRIPTION
I've made a few updates to the RQpy trigger simulation code.

- Added the ability to calculate FIR trigger amplitude for a constrained window `rqpy.sim.TrigSim.constrain_trigger`
- Added the ability to use multiple channels in the FIR trigger simulation using the `which_channel` kwarg when initializing `rqpy.sim.TrigSim`
- Fixed minor bugs in processing that could raise errors when calculating low frequency chi-squareds