### PR TITLE
Prepend zeros to basedumpnum when saving truth info in PulseSim

### DIFF
--- a/rqpy/sim/_pulse_sim.py
+++ b/rqpy/sim/_pulse_sim.py
@@ -852,7 +852,7 @@ def _save_truth_info(savefilepath, **kwargs):
         savefilename = savefilename[:8] + '_' + savefilename[8:]
 
     basedumpnum = kwargs['basedumpnum']
-    dd.io.save(f"{savefilepath}{savefilename}_truth_info_{basedumpnum}.h5", kwargs)
+    dd.io.save(f"{savefilepath}{savefilename}_truth_info_{basedumpnum:04d}.h5", kwargs)
 
 
 def _round_sig(x, sig=2):


### PR DESCRIPTION
This a small fix where I've made it so we prepend zeros to the saved file name in `_save_truth_info` for the PulseSim. This is just to make it so the number in the saved file name always has 4 numbers and is sorted correctly when listed.