### PR TITLE
Add explicit seaborn import for loading icefire cmap

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ mendeleev>=0.4.5
 qetpy>=1.1.0
 deepdish>=0.3.6
 scikit_learn>=0.20.2
+seaborn>=0.8.0

--- a/rqpy/__init__.py
+++ b/rqpy/__init__.py
@@ -9,3 +9,7 @@ from . import sim
 from . import utils
 from . import limit
 from . import constants
+
+# load seaborn colormaps
+from seaborn import cm
+del cm


### PR DESCRIPTION
Adding an explicit import for seaborn in order to load the various colormaps it adds to matplotlib (since we use icefire as a default for some of our plotting functions, e.g. `rqpy.densityplot`).