### PR TITLE
Added ability to show a basecut in rqpy.densityplot

### DIFF
--- a/rqpy/plotting/_core_plotting.py
+++ b/rqpy/plotting/_core_plotting.py
@@ -10,8 +10,8 @@ import types
 __all__ = [
     "hist",
     "scatter",
-    "densityplot",
     "passageplot",
+    "densityplot",
     "RatePlot",
     "conf_ellipse",
 ]
@@ -106,8 +106,14 @@ def hist(arr, nbins='auto', xlims=None, cuts=None, lgcrawdata=True,
         if bins is None:
             bins = np.histogram_bin_edges(arr, bins=nbins, range=xlims)
 
-        hist, _, _ = ax.hist(arr, bins=bins, histtype='step',
-                             label='Full data', linewidth=2, color=plt.cm.get_cmap(cmap)(0))
+        hist, _, _ = ax.hist(
+            arr,
+            bins=bins,
+            histtype='step',
+            label='Full data',
+            linewidth=2,
+            color=plt.cm.get_cmap(cmap)(0),
+        )
 
     colors = plt.cm.get_cmap(cmap)(np.linspace(0.1, 0.9, len(cuts)))
 
@@ -126,8 +132,14 @@ def hist(arr, nbins='auto', xlims=None, cuts=None, lgcrawdata=True,
         if bins is None:
             bins = np.histogram_bin_edges(arr[ctemp], bins=nbins, range=xlims)
 
-        hist, _, _  = ax.hist(arr[ctemp], bins=bins, histtype='step',
-                              label=label, linewidth=2, color=colors[ii])
+        hist, _, _  = ax.hist(
+            arr[ctemp],
+            bins=bins,
+            histtype='step',
+            label=label,
+            linewidth=2,
+            color=colors[ii],
+        )
 
     ax.tick_params(which="both", direction="in", right=True, top=True)
     ax.grid(linestyle="dashed")
@@ -241,11 +253,23 @@ def scatter(xvals, yvals, xlims=None, ylims=None, cuts=None, lgcrawdata=True, lg
     limitcut = xlimitcut & ylimitcut
 
     if lgcrawdata and len(cuts) > 0: 
-        ax.scatter(xvals[limitcut & ~cuts[0]], yvals[limitcut & ~cuts[0]],
-                   label='Full Data', c='b', s=ms, alpha=a)
+        ax.scatter(
+            xvals[limitcut & ~cuts[0]], yvals[limitcut & ~cuts[0]],
+            label='Full Data',
+            c='b',
+            s=ms,
+            alpha=a,
+        )
+
     elif lgcrawdata:
-        ax.scatter(xvals[limitcut], yvals[limitcut],
-                   label='Full Data', c='b', s=ms, alpha=a)
+        ax.scatter(
+            xvals[limitcut],
+            yvals[limitcut],
+            label='Full Data',
+            c='b',
+            s=ms,
+            alpha=a,
+        )
 
     colors = plt.cm.get_cmap(cmap)(np.linspace(0.1, 0.9, len(cuts)))
 
@@ -266,26 +290,32 @@ def scatter(xvals, yvals, xlims=None, ylims=None, cuts=None, lgcrawdata=True, lg
         if ii+1<len(cuts):
             cplot = cplot & ~cuts[ii+1]
 
-        ax.scatter(xvals[cplot], yvals[cplot],
-                   label=label, c=colors[ii][np.newaxis,...], s=ms, alpha=a)
+        ax.scatter(
+            xvals[cplot],
+            yvals[cplot],
+            label=label,
+            c=colors[ii][np.newaxis,...],
+            s=ms,
+            alpha=a,
+        )
 
     if xlims is None:
         if lgcrawdata and len(cuts)==0:
-            xrange = xvals.max()-xvals.min()
-            ax.set_xlim([xvals.min()-0.05*xrange, xvals.max()+0.05*xrange])
+            xrange = xvals.max() - xvals.min()
+            ax.set_xlim([xvals.min() - 0.05 * xrange, xvals.max() + 0.05 * xrange])
         elif len(cuts)>0:
-            xrange = xvals[cuts[0]].max()-xvals[cuts[0]].min()
-            ax.set_xlim([xvals[cuts[0]].min()-0.05*xrange, xvals[cuts[0]].max()+0.05*xrange])
+            xrange = xvals[cuts[0]].max() - xvals[cuts[0]].min()
+            ax.set_xlim([xvals[cuts[0]].min() - 0.05 * xrange, xvals[cuts[0]].max() + 0.05 * xrange])
     else:
         ax.set_xlim(xlims)
 
     if ylims is None:
         if lgcrawdata and len(cuts)==0:
-            yrange = yvals.max()-yvals.min()
-            ax.set_ylim([yvals.min()-0.05*yrange, yvals.max()+0.05*yrange])
+            yrange = yvals.max() - yvals.min()
+            ax.set_ylim([yvals.min() - 0.05 * yrange, yvals.max() + 0.05 * yrange])
         elif len(cuts)>0:
-            yrange = yvals[cuts[0]].max()-yvals[cuts[0]].min()
-            ax.set_ylim([yvals[cuts[0]].min()-0.05*yrange, yvals[cuts[0]].max()+0.05*yrange])
+            yrange = yvals[cuts[0]].max() - yvals[cuts[0]].min()
+            ax.set_ylim([yvals[cuts[0]].min() - 0.05 * yrange, yvals[cuts[0]].max() + 0.05 * yrange])
     else:
         ax.set_ylim(ylims)
 
@@ -404,18 +434,20 @@ def passageplot(arr, cuts, basecut=None, nbins=100, lgcequaldensitybins=False, x
         oldsum = ctemp.sum()
 
         if ii==0:
-            passage_output = rp.passage_fraction(arr,
-                                                 cut,
-                                                 basecut=ctemp & xlimitcut,
-                                                 nbins=nbins,
-                                                 lgcequaldensitybins=lgcequaldensitybins,
-                                                )
+            passage_output = rp.passage_fraction(
+                arr,
+                cut,
+                basecut=ctemp & xlimitcut,
+                nbins=nbins,
+                lgcequaldensitybins=lgcequaldensitybins,
+            )
         else:
-            passage_output = rp.passage_fraction(arr,
-                                                 cut,
-                                                 basecut=ctemp & xlimitcut,
-                                                 nbins=x_binned,
-                                                )
+            passage_output = rp.passage_fraction(
+                arr,
+                cut,
+                basecut=ctemp & xlimitcut,
+                nbins=x_binned,
+            )
 
         x_binned = passage_output[0]
         passage_binned = passage_output[1]
@@ -436,8 +468,15 @@ def passageplot(arr, cuts, basecut=None, nbins=100, lgcequaldensitybins=False, x
 
         bin_centers = (x_binned[1:]+x_binned[:-1])/2
 
-        ax.hist(bin_centers, bins=x_binned, weights=passage_binned, histtype='step', 
-                color=colors[ii], label=label, linewidth=2)
+        ax.hist(
+            bin_centers,
+            bins=x_binned,
+            weights=passage_binned,
+            histtype='step',
+            color=colors[ii],
+            label=label,
+            linewidth=2,
+        )
 
         if showerrorbar:
             passage_binned_biased = passage_output[2]
@@ -449,8 +488,15 @@ def passageplot(arr, cuts, basecut=None, nbins=100, lgcequaldensitybins=False, x
             err_top = np.pad(err_top, (0, 1), mode='constant', constant_values=(0, err_top[-1]))
             err_bottom = np.pad(err_bottom, (0, 1), mode='constant', constant_values=(0, err_bottom[-1]))
 
-            ax.fill_between(x_binned, err_top, y2=err_bottom, step='post',
-                            linewidth=1, alpha=0.5, color=colors[ii])
+            ax.fill_between(
+                x_binned,
+                err_top,
+                y2=err_bottom,
+                step='post',
+                linewidth=1,
+                alpha=0.5,
+                color=colors[ii],
+            )
 
     ax.set_xlim(xlims)
     ax.set_ylim(ylims)
@@ -529,11 +575,11 @@ def densityplot(xvals, yvals, xlims=None, ylims=None, nbins = (500,500), cut=Non
     ax.set_ylabel(labels['ylabel'])
 
     if xlims is not None:
-        xlimitcut = (xvals>xlims[0]) & (xvals<xlims[1])
+        xlimitcut = (xvals > xlims[0]) & (xvals < xlims[1])
     else:
         xlimitcut = np.ones(len(xvals), dtype=bool)
     if ylims is not None:
-        ylimitcut = (yvals>ylims[0]) & (yvals<ylims[1])
+        ylimitcut = (yvals > ylims[0]) & (yvals < ylims[1])
     else:
         ylimitcut = np.ones(len(yvals), dtype=bool)
 
@@ -552,9 +598,15 @@ def densityplot(xvals, yvals, xlims=None, ylims=None, nbins = (500,500), cut=Non
     else:
         norm = clrs.Normalize()
 
-    cax = ax.hist2d(xvals[limitcut & cut], yvals[limitcut & cut], bins=nbins,
-                    norm=norm, cmap=cmap)
-    cbar = fig.colorbar(cax[-1], label = 'Density of Data')
+    cax = ax.hist2d(
+        xvals[limitcut & cut],
+        yvals[limitcut & cut],
+        bins=nbins,
+        norm=norm,
+        cmap=cmap,
+    )
+
+    cbar = fig.colorbar(cax[-1], label='Density of Data')
     cbar.ax.tick_params(which="both", direction="in")
     ax.tick_params(which="both", direction="in", right=True, top=True)
     ax.grid(linestyle="dashed")
@@ -645,8 +697,10 @@ class RatePlot(RQpyPlot):
         self.ax.set_xlim(self._energy_range)
         self.ax.set_ylabel("$\partial R/\partial E_r$ [evts/keV/kg/day]")
         self.ax.set_xlabel("Energy [keV]")
-        self.ax.set_title(f"Spectrum of Events from {self._energy_range[0]:.1f} to "
-                          f"{self._energy_range[1]:.1f} keV")
+        self.ax.set_title(
+            f"Spectrum of Events from {self._energy_range[0]:.1f} to "
+            f"{self._energy_range[1]:.1f} keV"
+        )
 
 
     def _update_colors(self, linestyle):
@@ -788,12 +842,13 @@ class RatePlot(RQpyPlot):
                 drde = rp.limit.gauss_smear(xvals, drde, res, gauss_width=gauss_width)
                 label += f"\nWith {gauss_width}$\sigma_E$ Smearing"
 
-            self.ax.plot(xvals,
-                         drde,
-                         linestyle='--',
-                         label=label,
-                         **kwargs,
-                        )
+            self.ax.plot(
+                xvals,
+                drde,
+                linestyle='--',
+                label=label,
+                **kwargs,
+            )
 
         self._update_colors("--")
 

--- a/rqpy/plotting/_core_plotting.py
+++ b/rqpy/plotting/_core_plotting.py
@@ -574,13 +574,18 @@ def densityplot(xvals, yvals, xlims=None, ylims=None, nbins = (500,500), cut=Non
     ax.set_xlabel(labels['xlabel'])
     ax.set_ylabel(labels['ylabel'])
 
+    if cut is None:
+        cut = np.ones(shape=xvals.shape, dtype=bool)
+
     if xlims is not None:
         xlimitcut = (xvals > xlims[0]) & (xvals < xlims[1])
     else:
+        xlims = (np.min(xvals[cut]), np.max(xvals[cut]))
         xlimitcut = np.ones(len(xvals), dtype=bool)
     if ylims is not None:
         ylimitcut = (yvals > ylims[0]) & (yvals < ylims[1])
     else:
+        ylims = (np.min(yvals[cut]), np.max(yvals[cut]))
         ylimitcut = np.ones(len(yvals), dtype=bool)
 
     if np.sum(xlimitcut)==0:
@@ -589,9 +594,6 @@ def densityplot(xvals, yvals, xlims=None, ylims=None, nbins = (500,500), cut=Non
         raise ValueError("There are no y values in the specified range.")
 
     limitcut = xlimitcut & ylimitcut
-
-    if cut is None:
-        cut = np.ones(shape=xvals.shape, dtype=bool)
 
     if lgclognorm:
         norm = clrs.LogNorm()
@@ -602,6 +604,7 @@ def densityplot(xvals, yvals, xlims=None, ylims=None, nbins = (500,500), cut=Non
         xvals[limitcut & cut],
         yvals[limitcut & cut],
         bins=nbins,
+        range=(xlims, ylims),
         norm=norm,
         cmap=cmap,
     )

--- a/rqpy/plotting/_core_plotting.py
+++ b/rqpy/plotting/_core_plotting.py
@@ -33,21 +33,21 @@ def hist(arr, nbins='auto', xlims=None, cuts=None, lgcrawdata=True,
     xlims : list of float, optional
         The xlimits of the histogram. This is passed to plt.hist() range parameter.
     cuts : list, optional
-        List of masks of values to be plotted. The cuts will be applied in the order that they are listed, 
+        List of masks of values to be plotted. The cuts will be applied in the order that they are listed,
         such that any number of cuts can be plotted
     lgcrawdata : bool, optional
         If True, the raw data is plotted
     lgceff : bool, optional
-        If True, the cut efficiencies are printed in the legend. 
+        If True, the cut efficiencies are printed in the legend.
     lgclegend : bool, optional
         If True, the legend is plotted.
     labeldict : dict, optional
-        Dictionary to overwrite the labels of the plot. defaults are: 
-            labels = {'title' : 'Histogram', 
-                      'xlabel' : 'variable', 
-                      'ylabel' : 'Count', 
-                      'cut0' : '1st', 
-                      'cut1' : '2nd', 
+        Dictionary to overwrite the labels of the plot. defaults are:
+            labels = {'title' : 'Histogram',
+                      'xlabel' : 'variable',
+                      'ylabel' : 'Count',
+                      'cut0' : '1st',
+                      'cut1' : '2nd',
                       ...}
         Ex: to change just the title, pass: labeldict = {'title' : 'new title'}, to hist()
     ax : axes.Axes object, optional
@@ -69,9 +69,11 @@ def hist(arr, nbins='auto', xlims=None, cuts=None, lgcrawdata=True,
     elif not isinstance(cuts, list):
         cuts = [cuts]
 
-    labels = {'title'  : 'Histogram',
-              'xlabel' : 'variable',
-              'ylabel' : 'Count'}
+    labels = {
+        'title' : 'Histogram',
+        'xlabel' : 'variable',
+        'ylabel' : 'Count',
+    }
 
     for ii in range(len(cuts)):
 
@@ -173,17 +175,17 @@ def scatter(xvals, yvals, xlims=None, ylims=None, cuts=None, lgcrawdata=True, lg
     lgcrawdata : bool, optional
         If True, the raw data is plotted
     lgceff : bool, optional
-        If True, the efficiencies of each cut, with respect to the data that survived 
-        the previous cut, are printed in the legend. 
+        If True, the efficiencies of each cut, with respect to the data that survived
+        the previous cut, are printed in the legend.
     lgclegend : bool, optional
         If True, the legend is included in the plot.
     labeldict : dict, optional
-        Dictionary to overwrite the labels of the plot. defaults are: 
-            labels = {'title' : 'Scatter Plot', 
-                      'xlabel' : 'x variable', 
-                      'ylabel' : 'y variable', 
-                      'cut0' : '1st', 
-                      'cut1' : '2nd', 
+        Dictionary to overwrite the labels of the plot. defaults are:
+            labels = {'title' : 'Scatter Plot',
+                      'xlabel' : 'x variable',
+                      'ylabel' : 'y variable',
+                      'cut0' : '1st',
+                      'cut1' : '2nd',
                       ...}
         Ex: to change just the title, pass: labeldict = {'title' : 'new title'}, to scatter()
     ms : float, optional
@@ -209,9 +211,11 @@ def scatter(xvals, yvals, xlims=None, ylims=None, cuts=None, lgcrawdata=True, lg
     elif not isinstance(cuts, list):
         cuts = [cuts]
 
-    labels = {'title'  : 'Scatter Plot',
-              'xlabel' : 'x variable', 
-              'ylabel' : 'y variable'}
+    labels = {
+        'title' : 'Scatter Plot',
+        'xlabel' : 'x variable',
+        'ylabel' : 'y variable',
+    }
 
     for ii in range(len(cuts)):
 
@@ -338,10 +342,10 @@ def passageplot(arr, cuts, basecut=None, nbins=100, lgcequaldensitybins=False, x
     arr : array_like
         Array of values to be binned and plotted
     cuts : list, optional
-        List of masks of values to be plotted. The cuts will be applied in the order that 
+        List of masks of values to be plotted. The cuts will be applied in the order that
         they are listed, such that any number of cuts can be plotted.
     basecut : NoneType, array_like, optional
-        The base cut for comparison of the first cut in `cuts`. If left as None, then the 
+        The base cut for comparison of the first cut in `cuts`. If left as None, then the
         passage fraction is calculated using all of the inputted data for the first cut.
     nbins : int, str, optional
         This is the same as plt.hist() bins parameter. Defaults is 'sqrt'.
@@ -349,20 +353,20 @@ def passageplot(arr, cuts, basecut=None, nbins=100, lgcequaldensitybins=False, x
         If set to True, the bin widths are set such that each bin has the same number
         of data points within it. If left as False, then a constant bin width is used.
     xlims : list of float, optional
-        The xlimits of the passage fraction plot. 
+        The xlimits of the passage fraction plot.
     ylims : list of float, optional
         This is passed to the plot as the y limits. Set to (0, 1) by default.
     lgceff : bool, optional
-        If True, the total cut efficiencies are printed in the legend. 
+        If True, the total cut efficiencies are printed in the legend.
     lgclegend : bool, optional
         If True, the legend is plotted.
     labeldict : dict, optional
-        Dictionary to overwrite the labels of the plot. defaults are: 
-            labels = {'title' : 'Passage Fraction Plot', 
-                      'xlabel' : 'variable', 
-                      'ylabel' : 'Passage Fraction', 
-                      'cut0' : '1st', 
-                      'cut1' : '2nd', 
+        Dictionary to overwrite the labels of the plot. defaults are:
+            labels = {'title' : 'Passage Fraction Plot',
+                      'xlabel' : 'variable',
+                      'ylabel' : 'Passage Fraction',
+                      'cut0' : '1st',
+                      'cut1' : '2nd',
                       ...}
         Ex: to change just the title, pass: labeldict = {'title' : 'new title'}, to hist()
     ax : axes.Axes object, optional
@@ -387,9 +391,11 @@ def passageplot(arr, cuts, basecut=None, nbins=100, lgcequaldensitybins=False, x
     if not isinstance(cuts, list):
         cuts = [cuts]
 
-    labels = {'title'  : 'Passage Fraction Plot',
-              'xlabel' : 'variable',
-              'ylabel' : 'Passage Fraction'}
+    labels = {
+        'title' : 'Passage Fraction Plot',
+        'xlabel' : 'variable',
+        'ylabel' : 'Passage Fraction',
+    }
 
     for ii in range(len(cuts)):
 
@@ -509,8 +515,8 @@ def passageplot(arr, cuts, basecut=None, nbins=100, lgcequaldensitybins=False, x
     return fig, ax
 
 
-def densityplot(xvals, yvals, xlims=None, ylims=None, nbins = (500,500), cut=None,
-                labeldict=None, lgclognorm=True, ax=None, cmap='icefire'):
+def densityplot(xvals, yvals, xlims=None, ylims=None, nbins = (500,500), cut=None, labeldict=None,
+                lgclognorm=True, ax=None, cmap='icefire', plot_cut_data=False, basecut=None):
     """
     Function to plot RQ data as a density plot.
 
@@ -531,16 +537,27 @@ def densityplot(xvals, yvals, xlims=None, ylims=None, nbins = (500,500), cut=Non
     cut : array of bool, optional
         Mask of values to be plotted
     labeldict : dict, optional
-        Dictionary to overwrite the labels of the plot. defaults are : 
-            labels = {'title' : 'Histogram', 'xlabel' : 'variable', 'ylabel' : 'Count'}
+        Dictionary to overwrite the labels of the plot. defaults are:
+            labels = {
+                'title' : 'Histogram',
+                'xlabel' : 'variable',
+                'ylabel' : 'Count',
+                'basecut' : '',
+            }
         Ex: to change just the title, pass: labeldict = {'title' : 'new title'}, to densityplot()
     lgclognorm : bool, optional
-        If True (default), the color normilization for the density will be log scaled, rather 
-        than linear
+        If True (default), the color normilization for the density will be log scaled, rather
+        than linear.
     ax : axes.Axes object, optional
         Option to pass an existing Matplotlib Axes object to plot over, if it already exists.
     cmap : str, optional
         The colormap to use for plotting each cut. Default is 'icefire'.
+    plot_cut_data : bool, optional
+        Boolean value for whether or not to plot the data cut by `cut`. If only a subset of the original
+        data is desired to be plotted, then use `basecut` to trim the plotted data.
+    basecut : array of bool, optional
+        The base cut for comparison of `cut`. If left as None, then this is set as an array of
+        Trues of the same length as the input data. Only used if `plot_cut_data` is True.
 
     Returns
     -------
@@ -557,9 +574,12 @@ def densityplot(xvals, yvals, xlims=None, ylims=None, nbins = (500,500), cut=Non
 
     """
 
-    labels = {'title'  : 'Density Plot',
-              'xlabel' : 'x variable',
-              'ylabel' : 'y variable'}
+    labels = {
+        'title'  : 'Density Plot',
+        'xlabel' : 'x variable',
+        'ylabel' : 'y variable',
+        'basecut' : '',
+    }
 
     if labeldict is not None:
         for key in labeldict:
@@ -576,6 +596,9 @@ def densityplot(xvals, yvals, xlims=None, ylims=None, nbins = (500,500), cut=Non
 
     if cut is None:
         cut = np.ones(shape=xvals.shape, dtype=bool)
+
+    if basecut is None:
+        basecut = np.ones(shape=xvals.shape, dtype=bool)
 
     if xlims is not None:
         xlimitcut = (xvals > xlims[0]) & (xvals < xlims[1])
@@ -608,6 +631,29 @@ def densityplot(xvals, yvals, xlims=None, ylims=None, nbins = (500,500), cut=Non
         norm=norm,
         cmap=cmap,
     )
+
+    if plot_cut_data:
+        cmap_grey_arr = np.ones((1, 4))
+        cmap_grey_arr[:, :-1] = 0.9
+        cmap_grey = clrs.ListedColormap(cmap_grey_arr)
+
+        ax.hist2d(
+            xvals[limitcut & basecut],
+            yvals[limitcut & basecut],
+            bins=nbins,
+            range=(xlims, ylims),
+            norm=norm,
+            cmap=cmap_grey,
+            zorder=0,
+        )
+
+        if len(labels['basecut']) > 0:
+            labels['basecut'] += ' '
+
+        ax.scatter(
+            [], [], color=cmap_grey(0), label=f"Data removed by {labels['basecut']}cut", marker='s',
+        )
+        ax.legend()
 
     cbar = fig.colorbar(cax[-1], label='Density of Data')
     cbar.ax.tick_params(which="both", direction="in")

--- a/rqpy/plotting/_core_plotting.py
+++ b/rqpy/plotting/_core_plotting.py
@@ -556,8 +556,9 @@ def densityplot(xvals, yvals, xlims=None, ylims=None, nbins = (500,500), cut=Non
         Boolean value for whether or not to plot the data cut by `cut`. If only a subset of the original
         data is desired to be plotted, then use `basecut` to trim the plotted data.
     basecut : array of bool, optional
-        The base cut for comparison of `cut`. If left as None, then this is set as an array of
-        Trues of the same length as the input data. Only used if `plot_cut_data` is True.
+        The base cut for comparison with `cut`. See Notes for an example use case. If left as None, then
+        this is set as an array of Trues of the same length as the input data. Only used if
+        `plot_cut_data` is True.
 
     Returns
     -------
@@ -571,6 +572,22 @@ def densityplot(xvals, yvals, xlims=None, ylims=None, nbins = (500,500), cut=Non
     ValueError
         If there are no `xvals` in the range specified by `xlims`.
         If there are no `yvals` in the range specified by `ylims`.
+
+    Notes
+    -----
+    An example case of plotting the data removed by cut is shown below.
+
+    Say we have two cuts, `cut1` and `cut2`, that correspond to different subsets of the data,
+    and we want to plot the events that pass the union of these two cuts, `cut1 & cut2`. Also, we
+    do want to use `plot_cut_data` and `basecut` to show the data that was removed when we added
+    `cut2` to cut1`.
+
+    >>> fig, ax = rqpy.densityplot(xvals, yvals, cut=cut1 & cut2, plot_cut_data=True, basecut=cut1)
+
+    The above code would show the data that passes `cut1 & cut2` as a density. It would also show
+    the data that passes `cut1`, but not `cut1 & cut2`, as a grey 2D histogram. If we had left
+    `basecut` as None, then all of the raw data would have been plotted as a grey 2D histogram,
+    which may not be desired.
 
     """
 


### PR DESCRIPTION
I've added the ability to show the data that was removed by a cut in `rqpy.densityplot`. There are now two more kwargs:

1. `plot_cut_data` - boolean value for whether or not to plot the removed data
2. `basecut` - array of booleans that specifies the previous cut to compare to

There's also a new label `'basecut'` that was added to `labeldict`, which allows the user to name the `basecut` in the legend, if `plot_cut_data` is True.