### PR TITLE
Make rqpy.hist default to log scale

### DIFF
--- a/rqpy/plotting/_core_plotting.py
+++ b/rqpy/plotting/_core_plotting.py
@@ -184,6 +184,7 @@ def hist(arr, nbins='auto', xlims=None, cuts=None, lgcrawdata=True,
 
     ax.tick_params(which="both", direction="in", right=True, top=True)
     ax.grid(linestyle="dashed")
+    ax.set_yscale('log')
 
     if lgclegend:
         ax.legend(loc="best")


### PR DESCRIPTION
Made the simple change such that `rqpy.hist` defaults to a logarithmic y-scale. Resolves #148.