### PR TITLE
Add post baseline and ability to center constrained OF amplitude on the FPGA trigger time

### DIFF
--- a/rqpy/io/_load.py
+++ b/rqpy/io/_load.py
@@ -397,6 +397,8 @@ def get_traces_midgz(path, channels, det, convtoamps=None, lgcskip_empty=True, l
             "pollingendtime",
             "triggertime",
             "triggeramp",
+            "triggermask",
+            "triggerdetnum",
         ]
 
         columns_trigveto = [
@@ -425,6 +427,8 @@ def get_traces_midgz(path, channels, det, convtoamps=None, lgcskip_empty=True, l
             info_dict["triggeramp"].append(trig['TriggerAmplitude'])
             info_dict["pollingendtime"].append(ev["PollingEndTime"])
             info_dict["triggertime"].append(trig["TriggerTime"])
+            info_dict["triggermask"].append(trig["TriggerMask"])
+            info_dict["triggerdetnum"].append(trig["TriggerDetNum"])
 
             for d in set(det):
                 try:

--- a/rqpy/process/_process_rq.py
+++ b/rqpy/process/_process_rq.py
@@ -1574,7 +1574,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
                     triggertime_sim_constrained[jj] = res_trigsim_constrained[1]
 
             if setup.do_ofamp_constrained[chan_num]:
-                if setup.ofamp_constrained_usetrigsimcenter:
+                if setup.ofamp_constrained_usetrigsimcenter[chan_num]:
                     windowcenter_constrain = int(triggertime_sim[jj] * setup.fs - (signal.shape[-1]//2))
                     if setup.indstart is not None:
                         windowcenter_constrain -= setup.indstart

--- a/rqpy/process/_process_rq.py
+++ b/rqpy/process/_process_rq.py
@@ -434,6 +434,7 @@ class SetupRQ(object):
 
         self.do_baseline = [True]*self.nchan
         self.baseline_indbasepre = [len(self.templates[0])//3]*self.nchan
+        self.baseline_indbasepost = [2 * len(self.templates[0])//3]*self.nchan
 
         self.do_integral = [True]*self.nchan
         self.indstart_integral = [len(self.templates[0])//3]*self.nchan
@@ -1012,7 +1013,7 @@ class SetupRQ(object):
 
         self._check_of()
 
-    def adjust_baseline(self, lgcrun=True, indbasepre=None):
+    def adjust_baseline(self, lgcrun=True, indbasepre=None, indbasepost=None):
         """
         Method for adjusting the calculation of the DC baseline.
 
@@ -1033,10 +1034,16 @@ class SetupRQ(object):
         if indbasepre is None:
             indbasepre = len(self.templates[0])//3
 
-        lgcrun, indbasepre = self._check_arg_length(lgcrun=lgcrun, indbasepre=indbasepre)
+        if indbasepost is None:
+            indbasepost = 2 * len(self.templates[0])//3
+
+        lgcrun, indbasepre = self._check_arg_length(
+            lgcrun=lgcrun, indbasepre=indbasepre, indbasepost=indbasepost,
+        )
 
         self.do_baseline = lgcrun
         self.baseline_indbasepre = indbasepre
+        self.baseline_indbasepost = indbasepost
 
     def adjust_integral(self, lgcrun=True, indstart=None, indstop=None, indbasepre=None, indbasepost=None):
         """
@@ -1332,7 +1339,11 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
     if setup.do_baseline[chan_num]:
         baseline = np.mean(signal[:, :setup.baseline_indbasepre[chan_num]], axis=-1)
         rq_dict[f'baseline_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
-        rq_dict[f'baseline_{chan}{det}'][readout_inds] = baseline
+        rq_dict[f'baseline_{chan}{det}'][readout_inds] = baseline]
+
+        baseline_post = np.mean(signal[:, setup.baseline_indbasepost[chan_num]:], axis=-1)
+        rq_dict[f'baseline_post_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
+        rq_dict[f'baseline_post_{chan}{det}'][readout_inds] = baseline_post
 
     if setup.do_integral[chan_num]:
         if setup.do_baseline[chan_num]:

--- a/rqpy/process/_process_rq.py
+++ b/rqpy/process/_process_rq.py
@@ -1037,7 +1037,7 @@ class SetupRQ(object):
         if indbasepost is None:
             indbasepost = 2 * len(self.templates[0])//3
 
-        lgcrun, indbasepre = self._check_arg_length(
+        lgcrun, indbasepre, indbasepost = self._check_arg_length(
             lgcrun=lgcrun, indbasepre=indbasepre, indbasepost=indbasepost,
         )
 

--- a/rqpy/process/_process_rq.py
+++ b/rqpy/process/_process_rq.py
@@ -1575,7 +1575,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
 
             if setup.do_ofamp_constrained[chan_num]:
                 if setup.ofamp_constrained_usetrigsimcenter:
-                    windowcenter_constrain = triggertime_sim[jj] * setup.fs - (signal.shape[-1]//2)
+                    windowcenter_constrain = int(triggertime_sim[jj] * setup.fs - (signal.shape[-1]//2))
                     if setup.indstart is not None:
                         windowcenter_constrain -= setup.indstart
                 else:

--- a/rqpy/process/_process_rq.py
+++ b/rqpy/process/_process_rq.py
@@ -744,6 +744,14 @@ class SetupRQ(object):
         self.ofamp_constrained_pulse_constraint = pulse_direction_constraint
         self.ofamp_constrained_usetrigsimcenter = usetrigsimcenter
 
+        if any(usetrigsimcenter) and not any(self.do_trigsim):
+            warnings.warn(
+                "usetrigsimcenter has been sent to True, but the trigger "
+                "simulation has not been set to run. Unless this is changed "
+                "later, the constrained OF will instead center on the "
+                "specified windowcenter"
+            )
+
         self._check_of()
 
     def adjust_ofamp_baseline(self, lgcrun=True, lgcrun_smooth=False,

--- a/rqpy/process/_process_rq.py
+++ b/rqpy/process/_process_rq.py
@@ -101,6 +101,10 @@ class SetupRQ(object):
         pulse direction is set. If 1, then a positive pulse constraint is set for all fits. 
         If -1, then a negative pulse constraint is set for all fits. If any other value, then
         an ValueError will be raised. Each value in the list specifies this attribute for each channel.
+    ofamp_constrained_usetrigsimcenter : list of bool
+        If True, and if the trigger simulation has been run on the
+        specified channel, then the constrained Optimum Filter will
+        be centered on the trigger time.
     do_ofamp_pileup : list of bool
         Boolean flag for whether or not to do the pileup optimum filter fit. Each value in the list specifies 
         this attribute for each channel.
@@ -188,6 +192,10 @@ class SetupRQ(object):
     baseline_indbasepre : list of int
         The number of indices up to which a trace should be averaged to determine the baseline. Each value
         in the list specifies this attribute for each channel.
+    baseline_indbasepost : list of int
+        The number of indices after to which a trace should be averaged
+        to determine the post baseline. Each value in the list
+        specifies this attribute for each channel.
     do_integral : list of bool
         Boolean flag for whether or not to calculate the baseline-subtracted integral of each trace. Each value
         in the list specifies this attribute for each channel.
@@ -712,6 +720,10 @@ class SetupRQ(object):
             pulse direction is set. If 1, then a positive pulse constraint is set for all fits.
             If -1, then a negative pulse constraint is set for all fits. If any other value, then
             an ValueError will be raised.
+        usetrigsimcenter : bool, list of bool, optional
+            If True, and if the trigger simulation has been run on the
+            specified channel, then the constrained Optimum Filter will
+            be centered on the trigger time.
 
         """
 
@@ -1025,9 +1037,17 @@ class SetupRQ(object):
             baseline can be subtracted.
         indbasepre : int, list of int, optional
             The number of indices up to which a trace should be averaged to determine the baseline.
-            Can be set to a list of values, if indbasepre should be different for each channel. 
+            Can be set to a list of values, if indbasepre should be different for each channel.
             The length of the list should be the same length as the number of channels. Default
             is one-third of the trace length.
+        indbasepost : list of int
+            The number of indices after to which a trace should be
+            averaged to determine the post baseline. Can be set to a
+            list of values, if `indbasepost` should be different for
+            each channel. The length of the list should be the same
+            length as the number of channels. Default is two-thirds of
+            the trace length, i.e. average over the final one-third of
+            each trace.
 
         """
 

--- a/rqpy/process/_process_rq.py
+++ b/rqpy/process/_process_rq.py
@@ -1339,7 +1339,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
     if setup.do_baseline[chan_num]:
         baseline = np.mean(signal[:, :setup.baseline_indbasepre[chan_num]], axis=-1)
         rq_dict[f'baseline_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)
-        rq_dict[f'baseline_{chan}{det}'][readout_inds] = baseline]
+        rq_dict[f'baseline_{chan}{det}'][readout_inds] = baseline
 
         baseline_post = np.mean(signal[:, setup.baseline_indbasepost[chan_num]:], axis=-1)
         rq_dict[f'baseline_post_{chan}{det}'] = np.ones(len(readout_inds))*(-999999.0)

--- a/rqpy/process/_process_rq.py
+++ b/rqpy/process/_process_rq.py
@@ -1585,7 +1585,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
                     triggertime_sim_constrained[jj] = res_trigsim_constrained[1]
 
             if setup.do_ofamp_constrained[chan_num]:
-                if setup.ofamp_constrained_usetrigsimcenter[chan_num]:
+                if setup.ofamp_constrained_usetrigsimcenter[chan_num] and (setup.do_trigsim[chan_num] and setup.trigger == chan_num):
                     windowcenter_constrain = int(triggertime_sim[jj] * setup.fs - (signal.shape[-1]//2))
                     if setup.indstart is not None:
                         windowcenter_constrain -= setup.indstart

--- a/rqpy/process/_process_rq.py
+++ b/rqpy/process/_process_rq.py
@@ -406,6 +406,7 @@ class SetupRQ(object):
         self.ofamp_constrained_nconstrain = [80]*self.nchan
         self.ofamp_constrained_windowcenter = [0]*self.nchan
         self.ofamp_constrained_pulse_constraint = [0]*self.nchan
+        self.ofamp_constrained_usetrigsimcenter = [False] * self.nchan
 
         self.do_ofamp_pileup = [True]*self.nchan
         self.do_ofamp_pileup_smooth = [False]*self.nchan
@@ -1573,7 +1574,7 @@ def _calc_rq_single_channel(signal, template, psd, setup, readout_inds, chan, ch
                     triggertime_sim_constrained[jj] = res_trigsim_constrained[1]
 
             if setup.do_ofamp_constrained[chan_num]:
-                if setup.usetrigsimcenter:
+                if setup.ofamp_constrained_usetrigsimcenter:
                     windowcenter_constrain = triggertime_sim[jj] * setup.fs - (signal.shape[-1]//2)
                     if setup.indstart is not None:
                         windowcenter_constrain -= setup.indstart


### PR DESCRIPTION
I've had this on its own branch for a while, but in the RQ processing, I've added a new RQ and a new option to another RQ.

- Added `baseline_post` RQ
- Added option for `ofamp_constrained` to be centered on the FPGA trigger time (simulated)

I recently updated the docstrings, so this should finally be ready to merge to master.