### PR TITLE
Update readme to recommend pip install .

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 
 RQpy (Reduced Quantities) provides helpful tools for dark matter search related analysis. It contains submodules for processing, energy calibration, plotting, automated cut routines, and many other useful DM analysis tools. This repository is tailored specifically towards creating an efficient workflow for dark matter search analysis using detectors studied by the Pyle Group, and it may not generalize well to research using any detector.
 
-To install the most recent development version of RQpy, clone this repo, then from the top-level directory of the repo, type the following lines into your command line
+To install the most recent development version of RQpy, clone this repo, then from the top-level directory of the repo, type the following line into your command line
 
-`python setup.py clean`  
-`python setup.py install --user`
+`pip install .`
+
+If using a shared Python installation, you may want to add the `--user` flag to the above line.
 
 This package requires python 3.6 or greater. Use of the much of the functionality in the `io` and `process` submodules requires an installation of `scdmsPyTools` for IO purposes.
 


### PR DESCRIPTION
Updated the README to tell the user to use `pip install .` for the installation step. Recommended by Python and avoids the `clean` step.

See https://github.com/ucbpylegroup/QETpy/issues/92 and https://github.com/ucbpylegroup/QETpy/pull/101 for more info.