### PR TITLE
Add underscores to be compatible with QETpy DIDV

### DIFF
--- a/rqpy/process/_process_iv_didv.py
+++ b/rqpy/process/_process_iv_didv.py
@@ -202,8 +202,8 @@ def _process_ivfile(filepath, chans, detectorid, rfb, loopgain, binstovolts,
                 didvobj = DIDV(traces_temp[cut], fs[ii], sgfreq, sgamp, rshunt)
                 didvobj.processtraces()
                 
-                didvmean = didvobj.didvmean
-                didvstd = didvobj.didvstd
+                didvmean = didvobj._didvmean
+                didvstd = didvobj._didvstd
 
                 f = None
                 psd = None


### PR DESCRIPTION
Added the underscores needed to access the `qetpy.DIDV` attributes needed in the processing routines for IV/dIdV.