### PR TITLE
Add get_charge option to get_traces_midgz

### DIFF
--- a/rqpy/io/_load.py
+++ b/rqpy/io/_load.py
@@ -349,8 +349,8 @@ def get_traces_midgz(path, channels, det, convtoamps=None, lgcskip_empty=True, l
 
     """
 
-    if not HAS_SCDMSPYTOOLS:
-        raise ImportError("Cannot use get_traces_midgz because scdmsPyTools is not installed.")
+    if not HAS_RAWIO:
+        raise ImportError("Cannot use get_traces_midgz because cdms rawio is not installed.")
 
     if not isinstance(path, list):
         path = [path]


### PR DESCRIPTION
Added the optional argument `get_charge` to `rqpy.io.get_traces_midgz` to provide users with a function to get the charge channels of a CDMS detector, as requested by @ytcs.

Closes #170.