### PR TITLE
fix for numpy being downgraded after build environment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,5 +2,5 @@
 requires = [
     "wheel",
     "setuptools",
-    "numpy",
+    "oldest-supported-numpy",
 ]


### PR DESCRIPTION
some combination of pip, numpy, and tensorflow are causing having with rqpy requirnig numpy for the build environment. The proposed change seems to make it a bit more stable